### PR TITLE
Put lambda events to S3

### DIFF
--- a/cdk/lib/telemetry-stack.ts
+++ b/cdk/lib/telemetry-stack.ts
@@ -108,6 +108,14 @@ export class TelemetryStack extends Stack {
 
     const telemetryBackend = telemetryFunction();
 
+    const telemetryBackendPolicyStatement = new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ["s3:PutObject"],
+      resources: [telemetryDataBucket.bucketArn, `${telemetryDataBucket.bucketArn}/*`]
+    });
+
+    telemetryBackend.addToRolePolicy(telemetryBackendPolicyStatement);
+
     /**
      * API Gateway
      */

--- a/projects/event-api-lambda/.gitignore
+++ b/projects/event-api-lambda/.gitignore
@@ -1,5 +1,6 @@
 *.d.ts
 !types/*.d.ts
 coverage
+.tmp
 node_modules
 dist

--- a/projects/event-api-lambda/README.md
+++ b/projects/event-api-lambda/README.md
@@ -8,9 +8,13 @@ Deployed as part of this project – see the README in the project root for deta
 
 Run `npm i` to install.
 
+Locally, this project depends on localstack to simulate an AWS service, which requires `docker` as a dependency. Before starting the application, run `docker-compose up` in this folder to launch.
+
 Run `npm run start`. The app should then be accessible on port 3132.
 
 ## Testing
+
+Testing also relies on localstack – run `docker-compose up` before running your tests.
 
 Run `npm run test` to run the tests. The tests use [chai-http](https://www.chaijs.com/plugins/chai-http/) to allow us to mock HTTP requests.
 

--- a/projects/event-api-lambda/docker-compose.yml
+++ b/projects/event-api-lambda/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '2.1'
+
+services:
+  localstack:
+    container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
+    image: localstack/localstack
+    ports:
+      - "4566-4599:4566-4599"
+      - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
+    environment:
+      - SERVICES=s3
+      - DEBUG=true
+      - DATA_DIR=/tmp/localstack/data
+      - KINESIS_ERROR_PROBABILITY=0
+      - DOCKER_HOST=unix:///var/run/docker.sock
+    volumes:
+      - "./.tmp:/tmp/localstack"
+      - ./localstack:/docker-entrypoint-initaws.d
+      - "/var/run/docker.sock:/var/run/docker.sock"

--- a/projects/event-api-lambda/jest.config.js
+++ b/projects/event-api-lambda/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
-    preset: 'ts-jest/presets/default',
-    testMatch: ['**/__tests__/**/?(*.)+(spec|test).[jt]s?(x)'],
-}
+  preset: "ts-jest/presets/default",
+  testMatch: ["**/__tests__/**/?(*.)+(spec|test).[jt]s?(x)"],
+  testRunner: 'jest-circus'
+};

--- a/projects/event-api-lambda/localstack/buckets.sh
+++ b/projects/event-api-lambda/localstack/buckets.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Create our telemetry bucket for localstack
+awslocal s3 mb s3://telemetry-service

--- a/projects/event-api-lambda/package-lock.json
+++ b/projects/event-api-lambda/package-lock.json
@@ -179,10 +179,100 @@
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
             "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
         },
+        "@babel/plugin-syntax-async-generators": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-bigint": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+            "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-class-properties": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
+            "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-import-meta": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+            "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-json-strings": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-logical-assignment-operators": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+            "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-nullish-coalescing-operator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-numeric-separator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+            "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
         "@babel/plugin-syntax-object-rest-spread": {
             "version": "7.8.3",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
             "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-catch-binding": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-chaining": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+            "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.8.0"
             }
@@ -295,6 +385,14 @@
                         "url": "0.10.3",
                         "uuid": "3.3.2",
                         "xml2js": "0.4.19"
+                    },
+                    "dependencies": {
+                        "uuid": {
+                            "version": "3.3.2",
+                            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+                            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+                            "dev": true
+                        }
                     }
                 },
                 "buffer": {
@@ -448,6 +546,67 @@
                 }
             }
         },
+        "@istanbuljs/load-nyc-config": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+            "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.3.1",
+                "find-up": "^4.1.0",
+                "get-package-type": "^0.1.0",
+                "js-yaml": "^3.13.1",
+                "resolve-from": "^5.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                },
+                "resolve-from": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+                    "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+                    "dev": true
+                }
+            }
+        },
+        "@istanbuljs/schema": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+            "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+            "dev": true
+        },
         "@jest/console": {
             "version": "24.9.0",
             "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -512,6 +671,304 @@
                 "@jest/types": "^24.9.0",
                 "jest-message-util": "^24.9.0",
                 "jest-mock": "^24.9.0"
+            }
+        },
+        "@jest/globals": {
+            "version": "26.4.2",
+            "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.2.tgz",
+            "integrity": "sha512-Ot5ouAlehhHLRhc+sDz2/9bmNv9p5ZWZ9LE1pXGGTCXBasmi5jnYjlgYcYt03FBwLmZXCZ7GrL29c33/XRQiow==",
+            "dev": true,
+            "requires": {
+                "@jest/environment": "^26.3.0",
+                "@jest/types": "^26.3.0",
+                "expect": "^26.4.2"
+            },
+            "dependencies": {
+                "@jest/environment": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
+                    "integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/fake-timers": "^26.3.0",
+                        "@jest/types": "^26.3.0",
+                        "@types/node": "*",
+                        "jest-mock": "^26.3.0"
+                    }
+                },
+                "@jest/fake-timers": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
+                    "integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.3.0",
+                        "@sinonjs/fake-timers": "^6.0.1",
+                        "@types/node": "*",
+                        "jest-message-util": "^26.3.0",
+                        "jest-mock": "^26.3.0",
+                        "jest-util": "^26.3.0"
+                    }
+                },
+                "@jest/types": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^3.0.0",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "@types/istanbul-reports": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-report": "*"
+                    }
+                },
+                "@types/yargs": {
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+                    "dev": true,
+                    "requires": {
+                        "@types/yargs-parser": "*"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "diff-sequences": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
+                    "integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
+                    "dev": true
+                },
+                "escape-string-regexp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+                    "dev": true
+                },
+                "expect": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
+                    "integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.3.0",
+                        "ansi-styles": "^4.0.0",
+                        "jest-get-type": "^26.3.0",
+                        "jest-matcher-utils": "^26.4.2",
+                        "jest-message-util": "^26.3.0",
+                        "jest-regex-util": "^26.0.0"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "jest-diff": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
+                    "integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^4.0.0",
+                        "diff-sequences": "^26.3.0",
+                        "jest-get-type": "^26.3.0",
+                        "pretty-format": "^26.4.2"
+                    }
+                },
+                "jest-get-type": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+                    "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+                    "dev": true
+                },
+                "jest-matcher-utils": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
+                    "integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^4.0.0",
+                        "jest-diff": "^26.4.2",
+                        "jest-get-type": "^26.3.0",
+                        "pretty-format": "^26.4.2"
+                    }
+                },
+                "jest-message-util": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
+                    "integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@jest/types": "^26.3.0",
+                        "@types/stack-utils": "^1.0.1",
+                        "chalk": "^4.0.0",
+                        "graceful-fs": "^4.2.4",
+                        "micromatch": "^4.0.2",
+                        "slash": "^3.0.0",
+                        "stack-utils": "^2.0.2"
+                    }
+                },
+                "jest-mock": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
+                    "integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.3.0",
+                        "@types/node": "*"
+                    }
+                },
+                "jest-regex-util": {
+                    "version": "26.0.0",
+                    "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+                    "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
+                    "dev": true
+                },
+                "jest-util": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
+                    "integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.3.0",
+                        "@types/node": "*",
+                        "chalk": "^4.0.0",
+                        "graceful-fs": "^4.2.4",
+                        "is-ci": "^2.0.0",
+                        "micromatch": "^4.0.2"
+                    }
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "pretty-format": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+                    "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.3.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                },
+                "stack-utils": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
+                    "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
             }
         },
         "@jest/reporters": {
@@ -613,6 +1070,24 @@
             "dev": true,
             "requires": {
                 "lodash.isequal": "^4.5.0"
+            }
+        },
+        "@sinonjs/commons": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+            "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+            "dev": true,
+            "requires": {
+                "type-detect": "4.0.8"
+            }
+        },
+        "@sinonjs/fake-timers": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+            "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.7.0"
             }
         },
         "@types/aws-lambda": {
@@ -727,6 +1202,15 @@
                 "@types/range-parser": "*"
             }
         },
+        "@types/graceful-fs": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
+            "integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/istanbul-lib-coverage": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -768,10 +1252,32 @@
             "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==",
             "dev": true
         },
+        "@types/ndjson": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/ndjson/-/ndjson-2.0.0.tgz",
+            "integrity": "sha512-z1inV91BPfnnUwX0Q6TiIspIrhDsE7XJRGLutLGSRc++rQEqVzGxkG2xEKFgYjPVqaef4q3S4fXxcggJvfI70A==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "@types/through": "*"
+            }
+        },
         "@types/node": {
             "version": "14.6.2",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.2.tgz",
             "integrity": "sha512-onlIwbaeqvZyniGPfdw/TEhKIh79pz66L1q06WUQqJLnAb6wbjvOtepLYTGHTqzdXgBYIE3ZdmqHDGsRsbBz7A==",
+            "dev": true
+        },
+        "@types/normalize-package-data": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+            "dev": true
+        },
+        "@types/prettier": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.1.0.tgz",
+            "integrity": "sha512-hiYA88aHiEIgDmeKlsyVsuQdcFn3Z2VuFd/Xm/HCnGnPD8UFU5BM128uzzRVVGEzKDKYUrRsRH9S2o+NUy/3IA==",
             "dev": true
         },
         "@types/qs": {
@@ -831,6 +1337,21 @@
             "requires": {
                 "@types/node": "*"
             }
+        },
+        "@types/through": {
+            "version": "0.0.30",
+            "resolved": "https://registry.npmjs.org/@types/through/-/through-0.0.30.tgz",
+            "integrity": "sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/uuid": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+            "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+            "dev": true
         },
         "@types/yargs": {
             "version": "13.0.10",
@@ -989,6 +1510,15 @@
             "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
             "dev": true
         },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
         "arr-diff": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -1079,19 +1609,31 @@
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
         },
         "aws-sdk": {
-            "version": "2.507.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.507.0.tgz",
-            "integrity": "sha512-sOtaZONTfUx1jh9HzrWMLwoA2cZK2Xn2RAmGV4Y11NM2qhMePOQ501dhAq/ygKMZRffjw23b8mT1rAaDGTn05g==",
+            "version": "2.745.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.745.0.tgz",
+            "integrity": "sha512-YTmDvxb0foJC/iZOSsn+MdO4g9nPnlyRdhIpFqvPUkrFzWn5rP4mPtDJan2Eu0j4R02pdwfDhmvr82ckH2w7OQ==",
             "requires": {
-                "buffer": "4.9.1",
+                "buffer": "4.9.2",
                 "events": "1.1.1",
-                "ieee754": "1.1.8",
+                "ieee754": "1.1.13",
                 "jmespath": "0.15.0",
                 "querystring": "0.2.0",
                 "sax": "1.2.1",
                 "url": "0.10.3",
                 "uuid": "3.3.2",
                 "xml2js": "0.4.19"
+            },
+            "dependencies": {
+                "ieee754": {
+                    "version": "1.1.13",
+                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+                    "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+                },
+                "uuid": {
+                    "version": "3.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+                }
             }
         },
         "aws-serverless-express": {
@@ -1144,6 +1686,25 @@
             "integrity": "sha512-2EMA2P8Vp7lG0RAzr4HXqtYwacfMErOuv1U3wrvxHX6rD1sV6xS3WXG3r8TRQ2r6w8OhvSdWt+z41hQNwNm3Xw==",
             "requires": {
                 "@types/babel__traverse": "^7.0.6"
+            }
+        },
+        "babel-preset-current-node-syntax": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
+            "integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
+            "dev": true,
+            "requires": {
+                "@babel/plugin-syntax-async-generators": "^7.8.4",
+                "@babel/plugin-syntax-bigint": "^7.8.3",
+                "@babel/plugin-syntax-class-properties": "^7.8.3",
+                "@babel/plugin-syntax-import-meta": "^7.8.3",
+                "@babel/plugin-syntax-json-strings": "^7.8.3",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3"
             }
         },
         "babel-preset-jest": {
@@ -1390,9 +1951,9 @@
             }
         },
         "buffer": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-            "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
             "requires": {
                 "base64-js": "^1.0.2",
                 "ieee754": "^1.1.4",
@@ -1653,6 +2214,12 @@
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
+        "collect-v8-coverage": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+            "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
+            "dev": true
+        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -1891,10 +2458,22 @@
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
+        "decimal.js": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+            "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
+            "dev": true
+        },
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
             "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+        },
+        "dedent": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+            "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+            "dev": true
         },
         "deep-eql": {
             "version": "3.0.1",
@@ -1909,6 +2488,12 @@
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+        },
+        "deepmerge": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+            "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+            "dev": true
         },
         "defaults": {
             "version": "1.0.3",
@@ -2031,6 +2616,12 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+        },
+        "emittery": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.1.tgz",
+            "integrity": "sha512-d34LN4L6h18Bzz9xpoku2nPwKxCPlPMr3EEKTkoEBi+1/+b0lcRkRJ1UVyyZaKNeqGR3swcGl6s390DNO4YVgQ==",
+            "dev": true
         },
         "emoji-regex": {
             "version": "7.0.3",
@@ -2485,6 +3076,12 @@
             "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
             "dev": true
         },
+        "get-package-type": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+            "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+            "dev": true
+        },
         "get-stdin": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
@@ -2878,6 +3475,12 @@
                 "isobject": "^3.0.1"
             }
         },
+        "is-potential-custom-element-name": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+            "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+            "dev": true
+        },
         "is-regex": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
@@ -3060,6 +3663,1157 @@
                 "@jest/types": "^24.9.0",
                 "execa": "^1.0.0",
                 "throat": "^4.0.0"
+            }
+        },
+        "jest-circus": {
+            "version": "26.4.2",
+            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-26.4.2.tgz",
+            "integrity": "sha512-gzxoteivskdUTNxT7Jx6hrANsEm+x1wh8jaXmQCtzC7zoNWirk9chYdSosHFC4tJlfDZa0EsPreVAxLicLsV0w==",
+            "dev": true,
+            "requires": {
+                "@babel/traverse": "^7.1.0",
+                "@jest/environment": "^26.3.0",
+                "@jest/test-result": "^26.3.0",
+                "@jest/types": "^26.3.0",
+                "@types/node": "*",
+                "chalk": "^4.0.0",
+                "co": "^4.6.0",
+                "dedent": "^0.7.0",
+                "expect": "^26.4.2",
+                "is-generator-fn": "^2.0.0",
+                "jest-each": "^26.4.2",
+                "jest-matcher-utils": "^26.4.2",
+                "jest-message-util": "^26.3.0",
+                "jest-runner": "^26.4.2",
+                "jest-runtime": "^26.4.2",
+                "jest-snapshot": "^26.4.2",
+                "jest-util": "^26.3.0",
+                "pretty-format": "^26.4.2",
+                "stack-utils": "^2.0.2",
+                "throat": "^5.0.0"
+            },
+            "dependencies": {
+                "@jest/console": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.3.0.tgz",
+                    "integrity": "sha512-/5Pn6sJev0nPUcAdpJHMVIsA8sKizL2ZkcKPE5+dJrCccks7tcM7c9wbgHudBJbxXLoTbqsHkG1Dofoem4F09w==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.3.0",
+                        "@types/node": "*",
+                        "chalk": "^4.0.0",
+                        "jest-message-util": "^26.3.0",
+                        "jest-util": "^26.3.0",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "@jest/environment": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
+                    "integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/fake-timers": "^26.3.0",
+                        "@jest/types": "^26.3.0",
+                        "@types/node": "*",
+                        "jest-mock": "^26.3.0"
+                    }
+                },
+                "@jest/fake-timers": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
+                    "integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.3.0",
+                        "@sinonjs/fake-timers": "^6.0.1",
+                        "@types/node": "*",
+                        "jest-message-util": "^26.3.0",
+                        "jest-mock": "^26.3.0",
+                        "jest-util": "^26.3.0"
+                    }
+                },
+                "@jest/source-map": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.3.0.tgz",
+                    "integrity": "sha512-hWX5IHmMDWe1kyrKl7IhFwqOuAreIwHhbe44+XH2ZRHjrKIh0LO5eLQ/vxHFeAfRwJapmxuqlGAEYLadDq6ZGQ==",
+                    "dev": true,
+                    "requires": {
+                        "callsites": "^3.0.0",
+                        "graceful-fs": "^4.2.4",
+                        "source-map": "^0.6.0"
+                    }
+                },
+                "@jest/test-result": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.3.0.tgz",
+                    "integrity": "sha512-a8rbLqzW/q7HWheFVMtghXV79Xk+GWwOK1FrtimpI5n1la2SY0qHri3/b0/1F0Ve0/yJmV8pEhxDfVwiUBGtgg==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/console": "^26.3.0",
+                        "@jest/types": "^26.3.0",
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "collect-v8-coverage": "^1.0.0"
+                    }
+                },
+                "@jest/test-sequencer": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.2.tgz",
+                    "integrity": "sha512-83DRD8N3M0tOhz9h0bn6Kl6dSp+US6DazuVF8J9m21WAp5x7CqSMaNycMP0aemC/SH/pDQQddbsfHRTBXVUgog==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/test-result": "^26.3.0",
+                        "graceful-fs": "^4.2.4",
+                        "jest-haste-map": "^26.3.0",
+                        "jest-runner": "^26.4.2",
+                        "jest-runtime": "^26.4.2"
+                    }
+                },
+                "@jest/transform": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.3.0.tgz",
+                    "integrity": "sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/core": "^7.1.0",
+                        "@jest/types": "^26.3.0",
+                        "babel-plugin-istanbul": "^6.0.0",
+                        "chalk": "^4.0.0",
+                        "convert-source-map": "^1.4.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "graceful-fs": "^4.2.4",
+                        "jest-haste-map": "^26.3.0",
+                        "jest-regex-util": "^26.0.0",
+                        "jest-util": "^26.3.0",
+                        "micromatch": "^4.0.2",
+                        "pirates": "^4.0.1",
+                        "slash": "^3.0.0",
+                        "source-map": "^0.6.1",
+                        "write-file-atomic": "^3.0.0"
+                    }
+                },
+                "@jest/types": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
+                    "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-coverage": "^2.0.0",
+                        "@types/istanbul-reports": "^3.0.0",
+                        "@types/node": "*",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0"
+                    }
+                },
+                "@types/istanbul-reports": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
+                    "integrity": "sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/istanbul-lib-report": "*"
+                    }
+                },
+                "@types/yargs": {
+                    "version": "15.0.5",
+                    "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+                    "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+                    "dev": true,
+                    "requires": {
+                        "@types/yargs-parser": "*"
+                    }
+                },
+                "acorn": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+                    "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+                    "dev": true
+                },
+                "acorn-globals": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+                    "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+                    "dev": true,
+                    "requires": {
+                        "acorn": "^7.1.1",
+                        "acorn-walk": "^7.1.1"
+                    }
+                },
+                "acorn-walk": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+                    "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+                    "dev": true
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "anymatch": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+                    "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+                    "dev": true,
+                    "requires": {
+                        "normalize-path": "^3.0.0",
+                        "picomatch": "^2.0.4"
+                    }
+                },
+                "babel-jest": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
+                    "integrity": "sha512-sxPnQGEyHAOPF8NcUsD0g7hDCnvLL2XyblRBcgrzTWBB/mAIpWow3n1bEL+VghnnZfreLhFSBsFluRoK2tRK4g==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/transform": "^26.3.0",
+                        "@jest/types": "^26.3.0",
+                        "@types/babel__core": "^7.1.7",
+                        "babel-plugin-istanbul": "^6.0.0",
+                        "babel-preset-jest": "^26.3.0",
+                        "chalk": "^4.0.0",
+                        "graceful-fs": "^4.2.4",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "babel-plugin-istanbul": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+                    "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "^7.0.0",
+                        "@istanbuljs/load-nyc-config": "^1.0.0",
+                        "@istanbuljs/schema": "^0.1.2",
+                        "istanbul-lib-instrument": "^4.0.0",
+                        "test-exclude": "^6.0.0"
+                    }
+                },
+                "babel-plugin-jest-hoist": {
+                    "version": "26.2.0",
+                    "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
+                    "integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/template": "^7.3.3",
+                        "@babel/types": "^7.3.3",
+                        "@types/babel__core": "^7.0.0",
+                        "@types/babel__traverse": "^7.0.6"
+                    }
+                },
+                "babel-preset-jest": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.3.0.tgz",
+                    "integrity": "sha512-5WPdf7nyYi2/eRxCbVrE1kKCWxgWY4RsPEbdJWFm7QsesFGqjdkyLeu1zRkwM1cxK6EPIlNd6d2AxLk7J+t4pw==",
+                    "dev": true,
+                    "requires": {
+                        "babel-plugin-jest-hoist": "^26.2.0",
+                        "babel-preset-current-node-syntax": "^0.1.3"
+                    }
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "camelcase": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+                    "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "cliui": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+                    "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0",
+                        "wrap-ansi": "^6.2.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "cssom": {
+                    "version": "0.4.4",
+                    "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+                    "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+                    "dev": true
+                },
+                "cssstyle": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+                    "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+                    "dev": true,
+                    "requires": {
+                        "cssom": "~0.3.6"
+                    },
+                    "dependencies": {
+                        "cssom": {
+                            "version": "0.3.8",
+                            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+                            "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+                            "dev": true
+                        }
+                    }
+                },
+                "data-urls": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+                    "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+                    "dev": true,
+                    "requires": {
+                        "abab": "^2.0.3",
+                        "whatwg-mimetype": "^2.3.0",
+                        "whatwg-url": "^8.0.0"
+                    }
+                },
+                "detect-newline": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+                    "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+                    "dev": true
+                },
+                "diff-sequences": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
+                    "integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
+                    "dev": true
+                },
+                "domexception": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+                    "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+                    "dev": true,
+                    "requires": {
+                        "webidl-conversions": "^5.0.0"
+                    },
+                    "dependencies": {
+                        "webidl-conversions": {
+                            "version": "5.0.0",
+                            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+                            "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+                            "dev": true
+                        }
+                    }
+                },
+                "emoji-regex": {
+                    "version": "8.0.0",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                    "dev": true
+                },
+                "escape-string-regexp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+                    "dev": true
+                },
+                "expect": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
+                    "integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.3.0",
+                        "ansi-styles": "^4.0.0",
+                        "jest-get-type": "^26.3.0",
+                        "jest-matcher-utils": "^26.4.2",
+                        "jest-message-util": "^26.3.0",
+                        "jest-regex-util": "^26.0.0"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "fsevents": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+                    "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "html-encoding-sniffer": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+                    "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+                    "dev": true,
+                    "requires": {
+                        "whatwg-encoding": "^1.0.5"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "istanbul-lib-coverage": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+                    "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+                    "dev": true
+                },
+                "istanbul-lib-instrument": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+                    "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/core": "^7.7.5",
+                        "@istanbuljs/schema": "^0.1.2",
+                        "istanbul-lib-coverage": "^3.0.0",
+                        "semver": "^6.3.0"
+                    }
+                },
+                "jest-config": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.2.tgz",
+                    "integrity": "sha512-QBf7YGLuToiM8PmTnJEdRxyYy3mHWLh24LJZKVdXZ2PNdizSe1B/E8bVm+HYcjbEzGuVXDv/di+EzdO/6Gq80A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/core": "^7.1.0",
+                        "@jest/test-sequencer": "^26.4.2",
+                        "@jest/types": "^26.3.0",
+                        "babel-jest": "^26.3.0",
+                        "chalk": "^4.0.0",
+                        "deepmerge": "^4.2.2",
+                        "glob": "^7.1.1",
+                        "graceful-fs": "^4.2.4",
+                        "jest-environment-jsdom": "^26.3.0",
+                        "jest-environment-node": "^26.3.0",
+                        "jest-get-type": "^26.3.0",
+                        "jest-jasmine2": "^26.4.2",
+                        "jest-regex-util": "^26.0.0",
+                        "jest-resolve": "^26.4.0",
+                        "jest-util": "^26.3.0",
+                        "jest-validate": "^26.4.2",
+                        "micromatch": "^4.0.2",
+                        "pretty-format": "^26.4.2"
+                    }
+                },
+                "jest-diff": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
+                    "integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^4.0.0",
+                        "diff-sequences": "^26.3.0",
+                        "jest-get-type": "^26.3.0",
+                        "pretty-format": "^26.4.2"
+                    }
+                },
+                "jest-docblock": {
+                    "version": "26.0.0",
+                    "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz",
+                    "integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
+                    "dev": true,
+                    "requires": {
+                        "detect-newline": "^3.0.0"
+                    }
+                },
+                "jest-each": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.2.tgz",
+                    "integrity": "sha512-p15rt8r8cUcRY0Mvo1fpkOGYm7iI8S6ySxgIdfh3oOIv+gHwrHTy5VWCGOecWUhDsit4Nz8avJWdT07WLpbwDA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.3.0",
+                        "chalk": "^4.0.0",
+                        "jest-get-type": "^26.3.0",
+                        "jest-util": "^26.3.0",
+                        "pretty-format": "^26.4.2"
+                    }
+                },
+                "jest-environment-jsdom": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.3.0.tgz",
+                    "integrity": "sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/environment": "^26.3.0",
+                        "@jest/fake-timers": "^26.3.0",
+                        "@jest/types": "^26.3.0",
+                        "@types/node": "*",
+                        "jest-mock": "^26.3.0",
+                        "jest-util": "^26.3.0",
+                        "jsdom": "^16.2.2"
+                    }
+                },
+                "jest-environment-node": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.3.0.tgz",
+                    "integrity": "sha512-c9BvYoo+FGcMj5FunbBgtBnbR5qk3uky8PKyRVpSfe2/8+LrNQMiXX53z6q2kY+j15SkjQCOSL/6LHnCPLVHNw==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/environment": "^26.3.0",
+                        "@jest/fake-timers": "^26.3.0",
+                        "@jest/types": "^26.3.0",
+                        "@types/node": "*",
+                        "jest-mock": "^26.3.0",
+                        "jest-util": "^26.3.0"
+                    }
+                },
+                "jest-get-type": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.3.0.tgz",
+                    "integrity": "sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==",
+                    "dev": true
+                },
+                "jest-haste-map": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.3.0.tgz",
+                    "integrity": "sha512-DHWBpTJgJhLLGwE5Z1ZaqLTYqeODQIZpby0zMBsCU9iRFHYyhklYqP4EiG73j5dkbaAdSZhgB938mL51Q5LeZA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.3.0",
+                        "@types/graceful-fs": "^4.1.2",
+                        "@types/node": "*",
+                        "anymatch": "^3.0.3",
+                        "fb-watchman": "^2.0.0",
+                        "fsevents": "^2.1.2",
+                        "graceful-fs": "^4.2.4",
+                        "jest-regex-util": "^26.0.0",
+                        "jest-serializer": "^26.3.0",
+                        "jest-util": "^26.3.0",
+                        "jest-worker": "^26.3.0",
+                        "micromatch": "^4.0.2",
+                        "sane": "^4.0.3",
+                        "walker": "^1.0.7"
+                    }
+                },
+                "jest-jasmine2": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.2.tgz",
+                    "integrity": "sha512-z7H4EpCldHN1J8fNgsja58QftxBSL+JcwZmaXIvV9WKIM+x49F4GLHu/+BQh2kzRKHAgaN/E82od+8rTOBPyPA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/traverse": "^7.1.0",
+                        "@jest/environment": "^26.3.0",
+                        "@jest/source-map": "^26.3.0",
+                        "@jest/test-result": "^26.3.0",
+                        "@jest/types": "^26.3.0",
+                        "@types/node": "*",
+                        "chalk": "^4.0.0",
+                        "co": "^4.6.0",
+                        "expect": "^26.4.2",
+                        "is-generator-fn": "^2.0.0",
+                        "jest-each": "^26.4.2",
+                        "jest-matcher-utils": "^26.4.2",
+                        "jest-message-util": "^26.3.0",
+                        "jest-runtime": "^26.4.2",
+                        "jest-snapshot": "^26.4.2",
+                        "jest-util": "^26.3.0",
+                        "pretty-format": "^26.4.2",
+                        "throat": "^5.0.0"
+                    }
+                },
+                "jest-leak-detector": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.2.tgz",
+                    "integrity": "sha512-akzGcxwxtE+9ZJZRW+M2o+nTNnmQZxrHJxX/HjgDaU5+PLmY1qnQPnMjgADPGCRPhB+Yawe1iij0REe+k/aHoA==",
+                    "dev": true,
+                    "requires": {
+                        "jest-get-type": "^26.3.0",
+                        "pretty-format": "^26.4.2"
+                    }
+                },
+                "jest-matcher-utils": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
+                    "integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^4.0.0",
+                        "jest-diff": "^26.4.2",
+                        "jest-get-type": "^26.3.0",
+                        "pretty-format": "^26.4.2"
+                    }
+                },
+                "jest-message-util": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
+                    "integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "@jest/types": "^26.3.0",
+                        "@types/stack-utils": "^1.0.1",
+                        "chalk": "^4.0.0",
+                        "graceful-fs": "^4.2.4",
+                        "micromatch": "^4.0.2",
+                        "slash": "^3.0.0",
+                        "stack-utils": "^2.0.2"
+                    }
+                },
+                "jest-mock": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
+                    "integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.3.0",
+                        "@types/node": "*"
+                    }
+                },
+                "jest-regex-util": {
+                    "version": "26.0.0",
+                    "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+                    "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
+                    "dev": true
+                },
+                "jest-resolve": {
+                    "version": "26.4.0",
+                    "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.4.0.tgz",
+                    "integrity": "sha512-bn/JoZTEXRSlEx3+SfgZcJAVuTMOksYq9xe9O6s4Ekg84aKBObEaVXKOEilULRqviSLAYJldnoWV9c07kwtiCg==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.3.0",
+                        "chalk": "^4.0.0",
+                        "graceful-fs": "^4.2.4",
+                        "jest-pnp-resolver": "^1.2.2",
+                        "jest-util": "^26.3.0",
+                        "read-pkg-up": "^7.0.1",
+                        "resolve": "^1.17.0",
+                        "slash": "^3.0.0"
+                    }
+                },
+                "jest-runner": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.2.tgz",
+                    "integrity": "sha512-FgjDHeVknDjw1gRAYaoUoShe1K3XUuFMkIaXbdhEys+1O4bEJS8Avmn4lBwoMfL8O5oFTdWYKcf3tEJyyYyk8g==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/console": "^26.3.0",
+                        "@jest/environment": "^26.3.0",
+                        "@jest/test-result": "^26.3.0",
+                        "@jest/types": "^26.3.0",
+                        "@types/node": "*",
+                        "chalk": "^4.0.0",
+                        "emittery": "^0.7.1",
+                        "exit": "^0.1.2",
+                        "graceful-fs": "^4.2.4",
+                        "jest-config": "^26.4.2",
+                        "jest-docblock": "^26.0.0",
+                        "jest-haste-map": "^26.3.0",
+                        "jest-leak-detector": "^26.4.2",
+                        "jest-message-util": "^26.3.0",
+                        "jest-resolve": "^26.4.0",
+                        "jest-runtime": "^26.4.2",
+                        "jest-util": "^26.3.0",
+                        "jest-worker": "^26.3.0",
+                        "source-map-support": "^0.5.6",
+                        "throat": "^5.0.0"
+                    }
+                },
+                "jest-runtime": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.2.tgz",
+                    "integrity": "sha512-4Pe7Uk5a80FnbHwSOk7ojNCJvz3Ks2CNQWT5Z7MJo4tX0jb3V/LThKvD9tKPNVNyeMH98J/nzGlcwc00R2dSHQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/console": "^26.3.0",
+                        "@jest/environment": "^26.3.0",
+                        "@jest/fake-timers": "^26.3.0",
+                        "@jest/globals": "^26.4.2",
+                        "@jest/source-map": "^26.3.0",
+                        "@jest/test-result": "^26.3.0",
+                        "@jest/transform": "^26.3.0",
+                        "@jest/types": "^26.3.0",
+                        "@types/yargs": "^15.0.0",
+                        "chalk": "^4.0.0",
+                        "collect-v8-coverage": "^1.0.0",
+                        "exit": "^0.1.2",
+                        "glob": "^7.1.3",
+                        "graceful-fs": "^4.2.4",
+                        "jest-config": "^26.4.2",
+                        "jest-haste-map": "^26.3.0",
+                        "jest-message-util": "^26.3.0",
+                        "jest-mock": "^26.3.0",
+                        "jest-regex-util": "^26.0.0",
+                        "jest-resolve": "^26.4.0",
+                        "jest-snapshot": "^26.4.2",
+                        "jest-util": "^26.3.0",
+                        "jest-validate": "^26.4.2",
+                        "slash": "^3.0.0",
+                        "strip-bom": "^4.0.0",
+                        "yargs": "^15.3.1"
+                    }
+                },
+                "jest-serializer": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.3.0.tgz",
+                    "integrity": "sha512-IDRBQBLPlKa4flg77fqg0n/pH87tcRKwe8zxOVTWISxGpPHYkRZ1dXKyh04JOja7gppc60+soKVZ791mruVdow==",
+                    "dev": true,
+                    "requires": {
+                        "@types/node": "*",
+                        "graceful-fs": "^4.2.4"
+                    }
+                },
+                "jest-snapshot": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.4.2.tgz",
+                    "integrity": "sha512-N6Uub8FccKlf5SBFnL2Ri/xofbaA68Cc3MGjP/NuwgnsvWh+9hLIR/DhrxbSiKXMY9vUW5dI6EW1eHaDHqe9sg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.0.0",
+                        "@jest/types": "^26.3.0",
+                        "@types/prettier": "^2.0.0",
+                        "chalk": "^4.0.0",
+                        "expect": "^26.4.2",
+                        "graceful-fs": "^4.2.4",
+                        "jest-diff": "^26.4.2",
+                        "jest-get-type": "^26.3.0",
+                        "jest-haste-map": "^26.3.0",
+                        "jest-matcher-utils": "^26.4.2",
+                        "jest-message-util": "^26.3.0",
+                        "jest-resolve": "^26.4.0",
+                        "natural-compare": "^1.4.0",
+                        "pretty-format": "^26.4.2",
+                        "semver": "^7.3.2"
+                    },
+                    "dependencies": {
+                        "semver": {
+                            "version": "7.3.2",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                            "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                            "dev": true
+                        }
+                    }
+                },
+                "jest-util": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
+                    "integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.3.0",
+                        "@types/node": "*",
+                        "chalk": "^4.0.0",
+                        "graceful-fs": "^4.2.4",
+                        "is-ci": "^2.0.0",
+                        "micromatch": "^4.0.2"
+                    }
+                },
+                "jest-validate": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
+                    "integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.3.0",
+                        "camelcase": "^6.0.0",
+                        "chalk": "^4.0.0",
+                        "jest-get-type": "^26.3.0",
+                        "leven": "^3.1.0",
+                        "pretty-format": "^26.4.2"
+                    }
+                },
+                "jest-worker": {
+                    "version": "26.3.0",
+                    "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
+                    "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+                    "dev": true,
+                    "requires": {
+                        "@types/node": "*",
+                        "merge-stream": "^2.0.0",
+                        "supports-color": "^7.0.0"
+                    }
+                },
+                "jsdom": {
+                    "version": "16.4.0",
+                    "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
+                    "integrity": "sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==",
+                    "dev": true,
+                    "requires": {
+                        "abab": "^2.0.3",
+                        "acorn": "^7.1.1",
+                        "acorn-globals": "^6.0.0",
+                        "cssom": "^0.4.4",
+                        "cssstyle": "^2.2.0",
+                        "data-urls": "^2.0.0",
+                        "decimal.js": "^10.2.0",
+                        "domexception": "^2.0.1",
+                        "escodegen": "^1.14.1",
+                        "html-encoding-sniffer": "^2.0.1",
+                        "is-potential-custom-element-name": "^1.0.0",
+                        "nwsapi": "^2.2.0",
+                        "parse5": "5.1.1",
+                        "request": "^2.88.2",
+                        "request-promise-native": "^1.0.8",
+                        "saxes": "^5.0.0",
+                        "symbol-tree": "^3.2.4",
+                        "tough-cookie": "^3.0.1",
+                        "w3c-hr-time": "^1.0.2",
+                        "w3c-xmlserializer": "^2.0.0",
+                        "webidl-conversions": "^6.1.0",
+                        "whatwg-encoding": "^1.0.5",
+                        "whatwg-mimetype": "^2.3.0",
+                        "whatwg-url": "^8.0.0",
+                        "ws": "^7.2.3",
+                        "xml-name-validator": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "normalize-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+                    "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+                    "dev": true
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "parse-json": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+                    "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.0.0",
+                        "error-ex": "^1.3.1",
+                        "json-parse-even-better-errors": "^2.3.0",
+                        "lines-and-columns": "^1.1.6"
+                    }
+                },
+                "parse5": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+                    "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                },
+                "pretty-format": {
+                    "version": "26.4.2",
+                    "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
+                    "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+                    "dev": true,
+                    "requires": {
+                        "@jest/types": "^26.3.0",
+                        "ansi-regex": "^5.0.0",
+                        "ansi-styles": "^4.0.0",
+                        "react-is": "^16.12.0"
+                    }
+                },
+                "punycode": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+                    "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/normalize-package-data": "^2.4.0",
+                        "normalize-package-data": "^2.5.0",
+                        "parse-json": "^5.0.0",
+                        "type-fest": "^0.6.0"
+                    },
+                    "dependencies": {
+                        "type-fest": {
+                            "version": "0.6.0",
+                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                            "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+                            "dev": true
+                        }
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+                    "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^4.1.0",
+                        "read-pkg": "^5.2.0",
+                        "type-fest": "^0.8.1"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                },
+                "stack-utils": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
+                    "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^2.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+                    "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "test-exclude": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+                    "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+                    "dev": true,
+                    "requires": {
+                        "@istanbuljs/schema": "^0.1.2",
+                        "glob": "^7.1.4",
+                        "minimatch": "^3.0.4"
+                    }
+                },
+                "throat": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+                    "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+                    "dev": true
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                },
+                "tough-cookie": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+                    "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+                    "dev": true,
+                    "requires": {
+                        "ip-regex": "^2.1.0",
+                        "psl": "^1.1.28",
+                        "punycode": "^2.1.1"
+                    }
+                },
+                "tr46": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+                    "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+                    "dev": true,
+                    "requires": {
+                        "punycode": "^2.1.1"
+                    }
+                },
+                "webidl-conversions": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+                    "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+                    "dev": true
+                },
+                "whatwg-url": {
+                    "version": "8.2.1",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.2.1.tgz",
+                    "integrity": "sha512-ZmVCr6nfBeaMxEHALLEGy0LszYjpJqf6PVNQUQ1qd9Et+q7Jpygd4rGGDXgHjD8e99yLFseD69msHDM4YwPZ4A==",
+                    "dev": true,
+                    "requires": {
+                        "lodash.sortby": "^4.7.0",
+                        "tr46": "^2.0.2",
+                        "webidl-conversions": "^6.1.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "write-file-atomic": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+                    "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+                    "dev": true,
+                    "requires": {
+                        "imurmurhash": "^0.1.4",
+                        "is-typedarray": "^1.0.0",
+                        "signal-exit": "^3.0.2",
+                        "typedarray-to-buffer": "^3.1.5"
+                    }
+                },
+                "ws": {
+                    "version": "7.3.1",
+                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+                    "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "15.4.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+                    "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^6.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^4.1.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^4.2.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^18.1.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "18.1.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    },
+                    "dependencies": {
+                        "camelcase": {
+                            "version": "5.3.1",
+                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                            "dev": true
+                        }
+                    }
+                }
             }
         },
         "jest-config": {
@@ -3427,6 +5181,16 @@
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
+        "js-yaml": {
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+            "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -3481,6 +5245,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+        },
+        "json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true
         },
         "json-schema": {
             "version": "0.2.3",
@@ -3566,6 +5336,12 @@
                 "prelude-ls": "~1.1.2",
                 "type-check": "~0.3.2"
             }
+        },
+        "lines-and-columns": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+            "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+            "dev": true
         },
         "load-json-file": {
             "version": "4.0.0",
@@ -4015,6 +5791,30 @@
             "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
             "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
             "dev": true
+        },
+        "ndjson": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-2.0.0.tgz",
+            "integrity": "sha512-nGl7LRGrzugTtaFcJMhLbpzJM6XdivmbkdlaGcrk/LXg2KL/YBC6z1g70xh0/al+oFuVFP8N8kiWRucmeEH/qQ==",
+            "requires": {
+                "json-stringify-safe": "^5.0.1",
+                "minimist": "^1.2.5",
+                "readable-stream": "^3.6.0",
+                "split2": "^3.0.0",
+                "through2": "^4.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
         },
         "negotiator": {
             "version": "0.6.2",
@@ -4670,6 +6470,11 @@
                     "version": "6.5.2",
                     "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
                     "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+                },
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
                 }
             }
         },
@@ -4793,6 +6598,15 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
             "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "saxes": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+            "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+            "dev": true,
+            "requires": {
+                "xmlchars": "^2.2.0"
+            }
         },
         "semver": {
             "version": "5.7.1",
@@ -5070,6 +6884,32 @@
                 "extend-shallow": "^3.0.0"
             }
         },
+        "split2": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+            "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+            "requires": {
+                "readable-stream": "^3.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
         "sshpk": {
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -5176,7 +7016,6 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.0"
             }
@@ -5323,6 +7162,26 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
             "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
+        },
+        "through2": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+            "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+            "requires": {
+                "readable-stream": "3"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
         },
         "tmpl": {
             "version": "1.0.4",
@@ -5534,6 +7393,12 @@
             "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
             "dev": true
         },
+        "type-fest": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "dev": true
+        },
         "type-is": {
             "version": "1.6.18",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -5541,6 +7406,15 @@
             "requires": {
                 "media-typer": "0.3.0",
                 "mime-types": "~2.1.24"
+            }
+        },
+        "typedarray-to-buffer": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+            "dev": true,
+            "requires": {
+                "is-typedarray": "^1.0.0"
             }
         },
         "typescript": {
@@ -5795,8 +7669,7 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "util.promisify": {
             "version": "1.0.1",
@@ -5815,9 +7688,9 @@
             "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
         },
         "uuid": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+            "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
         },
         "validate-npm-package-license": {
             "version": "3.0.4",
@@ -5849,6 +7722,15 @@
             "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
             "requires": {
                 "browser-process-hrtime": "^1.0.0"
+            }
+        },
+        "w3c-xmlserializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+            "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+            "dev": true,
+            "requires": {
+                "xml-name-validator": "^3.0.0"
             }
         },
         "walker": {
@@ -5975,6 +7857,12 @@
             "version": "9.0.7",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
             "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        },
+        "xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true
         },
         "xtend": {
             "version": "4.0.2",

--- a/projects/event-api-lambda/package.json
+++ b/projects/event-api-lambda/package.json
@@ -10,10 +10,13 @@
     "@guardian/node-riffraff-artifact": "^0.1.9",
     "@types/aws-serverless-express": "^3.3.1",
     "@types/express": "^4.17.0",
+    "@types/ndjson": "^2.0.0",
+    "@types/uuid": "^8.3.0",
     "@vercel/ncc": "^0.24.0",
     "chai": "^4.1.2",
     "chai-http": "^4.0.0",
     "dotenv": "^8.0.0",
+    "jest-circus": "^26.4.2",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.3.0",
     "ts-node-dev": "^1.0.0-pre.40",
@@ -25,18 +28,20 @@
     "start": "ts-node-dev --ignore-watch node_modules src/index.ts",
     "validate": "cd ../.. && script/make validate-logging",
     "fix": "cd ../.. && script/make fix-logging",
-    "test": "jest --coverage",
-    "test:watch": "jest --watch",
+    "test": "JEST_CIRCUS=1 jest --coverage",
+    "test:watch": "JEST_CIRCUS=1 jest --watch",
     "generate-schema": "typescript-json-schema ./src/types.ts IEventApiInput --out ./src/schema/eventApiInput.schema.json --required"
   },
   "dependencies": {
     "@types/aws-lambda": "^8.10.31",
     "@types/jest": "^24.0.17",
     "ajv": "^6.12.4",
-    "aws-sdk": "2.507.0",
+    "aws-sdk": "^2.745.0",
     "aws-serverless-express": "^3.3.6",
     "express": "^4.17.1",
     "jest": "^24.8.0",
-    "typescript-json-schema": "^0.43.0"
+    "ndjson": "^2.0.0",
+    "typescript-json-schema": "^0.43.0",
+    "uuid": "^8.3.0"
   }
 }

--- a/projects/event-api-lambda/src/__tests__/application.spec.ts
+++ b/projects/event-api-lambda/src/__tests__/application.spec.ts
@@ -2,6 +2,9 @@ import { createApp } from "../application";
 import chai from "chai";
 import chaiHttp from "chai-http";
 
+import { telemetryBucketName } from "../constants";
+import { s3 } from "../aws";
+
 chai.use(chaiHttp);
 chai.should();
 
@@ -87,7 +90,7 @@ describe("Event API lambda", () => {
         {
           stage: "PROD",
           type: "USER_ACTION_1",
-          value: 1
+          value: 1,
         },
       ];
 
@@ -104,7 +107,7 @@ describe("Event API lambda", () => {
           },
         ],
         message: "Incorrect event format",
-        status: "error"
+        status: "error",
       };
 
       return chai
@@ -135,6 +138,38 @@ describe("Event API lambda", () => {
         .then((res) => {
           expect(res.status).toBe(204);
         });
+    });
+
+    it("should write well-formed requests to S3 as NDJSON, and return the file key for easy retrieval", async () => {
+      const request = [
+        {
+          app: "example-app",
+          stage: "PROD",
+          type: "USER_ACTION_1",
+          value: 1,
+          eventTime: "2020-09-03T11:39:42.936Z",
+        },
+      ];
+
+      const res = await chai.request(testApp).post("/event").send(request);
+
+      const expectedResponse = {
+        message: "data/2020-09-03/2020-09-03T17:34:37.839Z-mock-uuid",
+        status: "ok",
+      };
+
+      expect(res.status).toBe(201);
+      expect(res.body).toEqual(expectedResponse);
+
+      const params = {
+        Bucket: telemetryBucketName,
+        Key: res.body.message,
+      };
+      const writtenFile = await s3.getObject(params).promise();
+
+      // We expect the file to contain our request as NDJSON
+      const expectedFileContents = `${JSON.stringify(request[0])}\n`;
+      expect(writtenFile.Body?.toString()).toBe(expectedFileContents);
     });
   });
 });

--- a/projects/event-api-lambda/src/__tests__/utils.spec.ts
+++ b/projects/event-api-lambda/src/__tests__/utils.spec.ts
@@ -1,0 +1,31 @@
+import { IUserTelemetryEvent } from "../../../definitions/IUserTelemetryEvent";
+import { convertEventsToNDJSON } from "../util";
+
+describe("utils", () => {
+  describe("convertEventsToNDJSON", () => {
+    it("should convert an array of event data to a single NDJSON string", () => {
+      const events: IUserTelemetryEvent[] = [
+        {
+          app: "example-app",
+          stage: "PROD",
+          type: "USER_ACTION_1",
+          value: 1,
+          eventTime: "2020-09-03T07:51:27.669Z",
+        },
+        {
+          app: "example-app",
+          stage: "PROD",
+          type: "USER_ACTION_2",
+          value: 1,
+          eventTime: "2020-09-03T07:51:27.669Z",
+        },
+      ];
+
+      const expected = `{\"app\":\"example-app\",\"stage\":\"PROD\",\"type\":\"USER_ACTION_1\",\"value\":1,\"eventTime\":\"2020-09-03T07:51:27.669Z\"}
+{\"app\":\"example-app\",\"stage\":\"PROD\",\"type\":\"USER_ACTION_2\",\"value\":1,\"eventTime\":\"2020-09-03T07:51:27.669Z\"}
+`;
+
+      expect(convertEventsToNDJSON(events)).toBe(expected);
+    });
+  });
+});

--- a/projects/event-api-lambda/src/aws.ts
+++ b/projects/event-api-lambda/src/aws.ts
@@ -1,0 +1,28 @@
+import AWS from "aws-sdk";
+
+/**
+ * Is this application running locally, or in AWS?
+ *
+ * Heuristics:
+ *  – if require.main is the current module, this file was run directly by node.
+ *  – if jest is available globally, we're running in a test.
+ */
+export const isRunningLocally =
+  !process.env.LAMBDA_TASK_ROOT && !process.env.AWS_EXECUTION_ENV;
+
+// We use localstack to mock AWS services if we are running locally.
+if (isRunningLocally) {
+  AWS.config.update({
+    accessKeyId: "xyz",
+    secretAccessKey: "qwe",
+    s3ForcePathStyle: true
+  });
+}
+
+const awsOptions = isRunningLocally
+  ? {
+      endpoint: "http://localhost:4566",
+    }
+  : undefined;
+
+export const s3 = new AWS.S3(awsOptions);

--- a/projects/event-api-lambda/src/constants.ts
+++ b/projects/event-api-lambda/src/constants.ts
@@ -1,0 +1,1 @@
+export const telemetryBucketName = process.env.TELEMETRY_BUCKET_NAME || 'telemetry-service';

--- a/projects/event-api-lambda/src/index.ts
+++ b/projects/event-api-lambda/src/index.ts
@@ -2,7 +2,9 @@ require("dotenv").config();
 
 import awsServerlessExpress from "aws-serverless-express";
 import { Handler } from "aws-lambda";
+
 import { createApp } from "./application";
+import { isRunningLocally } from "./aws";
 
 const app = createApp();
 
@@ -14,10 +16,7 @@ export const handler: Handler = (event, context) => {
   );
 };
 
-// If require.main is the current module, this file was run
-// directly by node, and we should start the app immediately –
-// it's running locally.
-if (require.main === module) {
+if (isRunningLocally) {
   const port = 3132;
 
   app.listen(port, () => {

--- a/projects/event-api-lambda/src/types.ts
+++ b/projects/event-api-lambda/src/types.ts
@@ -1,3 +1,7 @@
-import { IUserTelemetryEvent } from '../../definitions/IUserTelemetryEvent';
+import { IUserTelemetryEvent } from "../../definitions/IUserTelemetryEvent";
 
 export type IEventApiInput = IUserTelemetryEvent[];
+
+export type Either<Left, Right> =
+  | { value: Left; error: undefined }
+  | { error: Right; value: undefined };

--- a/projects/event-api-lambda/src/util.ts
+++ b/projects/event-api-lambda/src/util.ts
@@ -1,0 +1,75 @@
+import ndjson from "ndjson";
+import Ajv from "ajv";
+import { v4 as uuidv4 } from 'uuid';
+
+import eventApiInputSchema from "./schema/eventApiInput.schema.json";
+import { IUserTelemetryEvent } from "../../definitions/IUserTelemetryEvent";
+import { Either } from "./types";
+import { s3 } from "./aws";
+import { telemetryBucketName } from "./constants";
+
+/**
+ * @return The key of the file that's been added.
+ */
+export const putEventsIntoS3Bucket = async (events: IUserTelemetryEvent[]): Promise<string> => {
+  if (!telemetryBucketName) {
+    throw new Error(
+      `Configuration error: no value provided for environment variable TELEMETRY_BUCKET_NAME`
+    );
+  }
+
+  // Data is partitioned by day, in format YYYY-MM-DD. The filename
+  // contains an ISO date to aid discovery, and a uuid to ensure uniqueness.
+  const now = new Date();
+  const telemetryBucketKey = `data/${getYYYYmmddDate(now)}/${now.toISOString()}-${uuidv4()}`;
+  const eventsJSON = convertEventsToNDJSON(events);
+
+  const params = {
+    Bucket: telemetryBucketName,
+    Key: telemetryBucketKey,
+    Body: eventsJSON,
+    ContentType: "application/json",
+  };
+
+  await s3.putObject(params).promise();
+  return telemetryBucketKey;
+};
+
+export const convertEventsToNDJSON = (events: IUserTelemetryEvent[]) => {
+  const stringify = ndjson.stringify();
+  let buffer = "";
+  stringify.on("data", (line) => (buffer += line));
+  events.forEach((event) => stringify.write(event));
+  stringify.end();
+  return buffer;
+};
+
+export const createParseEventJson = () => {
+  const ajv = new Ajv();
+  const validateEventApiInput = ajv.compile(eventApiInputSchema);
+
+  return (
+    maybeEventJson: unknown
+  ): Either<IUserTelemetryEvent[], Ajv.ErrorObject[]> => {
+    const isInputValid = validateEventApiInput(maybeEventJson);
+    if (!isInputValid) {
+      const error = validateEventApiInput.errors!;
+      return left(error);
+    }
+    return right(maybeEventJson as IUserTelemetryEvent[]);
+  };
+};
+
+export const getYYYYmmddDate = (date: Date) => date.toISOString().split("T")[0];
+
+/**
+ * Constructors for the Either type.
+ */
+export const left = <Value, Error>(error: Error): Either<Value, Error> => ({
+  value: undefined,
+  error,
+});
+export const right = <Value, Error>(value: Value): Either<Value, Error> => ({
+  value,
+  error: undefined,
+});

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+
+set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=${DIR}/..

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=${DIR}/..

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,3 +1,41 @@
-#!/bin/sh -e
+#!/usr/bin/env bash
 
-(cd projects/event-api-lambda && npm i && npm run test && npm run build && npm run deploy)
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR=${DIR}/..
+
+EVENT_API_LAMBDA_DIR="$ROOT_DIR/projects/event-api-lambda"
+EVENT_API_LAMBDA_BUCKET_NAME=telemetry-service
+
+function setupEventApiLambda {
+  cd $EVENT_API_LAMBDA_DIR
+  docker-compose up -d
+  # Ensure localstack is up, and relevant resources have been created
+  for attempt in {1..3}
+  do
+    AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local aws s3 ls $EVENT_API_LAMBDA_BUCKET_NAME --endpoint-url http://localhost:4566 \
+      && break
+    sleep 5
+  done
+  npm i
+  npm run test
+  npm run build
+  npm run deploy
+}
+
+function teardownEventApiLambda {
+  cd $EVENT_API_LAMBDA_DIR
+  docker-compose down
+}
+
+function setup {
+  setupEventApiLambda
+}
+
+function teardown {
+  teardownEventApiLambda
+}
+
+trap teardown EXIT
+
+setup
+teardown


### PR DESCRIPTION
## What does this change?

Adds code to persist the incoming events defined in #4 to S3.

### Implementation details

I've added [localstack](https://github.com/localstack/localstack) to provide us with a mock service in local and test environments. As a result the tests for this behaviour are effectively integration tests with locally mocked services – we simulate a HTTP request, and check to ensure there's a file written to the appropriate bucket in localstack S3.

This will also be handy when running this service locally, for example when testing our event-sending client library.

## How to test

Posting events to the API Gateway endpoint in PROD should yield files containing events in the appropriate event bucket.

## How can we measure success?

The lambda correctly writes files to S3.

The automated tests do a good job of verifying this behaviour in a local environment.

CI runs those tests and passes.