### PR TITLE
Rename service to user-telemetry-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# editorial-tools-telemetry-service
+# editorial-tools-user-telemetry-service
 
 A service to receive telemetry events and pass them on to a kinesis stream. Designed to be used across the Guardian's Editorial Tools to help the team gather data about tool usage.
 
@@ -8,10 +8,10 @@ In `/cdk`, run `npm i` to install dependencies, and `npm run synth` to generate 
 
 ## Deploying
 
-To release changes, deploy the `editorial-tools-telemetry-service` project in Riffraff.
+To release changes, deploy the `editorial-tools-user-telemetry-service` project in Riffraff.
 
 ## Deploying
 
-To release changes, deploy the `editorial-tools-telemetry-service` project in Riffraff.
+To release changes, deploy the `editorial-tools-user-telemetry-service` project in Riffraff.
 
 

--- a/cdk/lib/telemetry-stack.ts
+++ b/cdk/lib/telemetry-stack.ts
@@ -59,10 +59,10 @@ export class TelemetryStack extends Stack {
 
     const telemetryDataBucket = new Bucket(
       this,
-      "tools-telemetry-data-bucket",
+      "user-telemetry-data-bucket",
       {
         versioned: false,
-        bucketName: "tools-telemetry-data",
+        bucketName: "user-telemetry-data",
         encryption: BucketEncryption.KMS_MANAGED,
         publicReadAccess: false,
         blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
@@ -140,14 +140,14 @@ export class TelemetryStack extends Stack {
 
     const telemetryCertificate = acm.Certificate.fromCertificateArn(
       this,
-      "tools-telemetry-certificate",
+      "user-telemetry-certificate",
       telemetryCertificateArn.valueAsString
     );
 
 
     const telemetryDomainName = new apigateway.DomainName(
       this,
-      "tools-telemetry-domain-name",
+      "user-telemetry-domain-name",
       {
         domainName: telemetryHostName.valueAsString,
         certificate: telemetryCertificate,
@@ -157,7 +157,7 @@ export class TelemetryStack extends Stack {
 
     telemetryDomainName.addBasePathMapping(telemetryApi, { basePath: "" });
 
-    new CfnOutput(this, "tools-telemetry-api-target-hostname", {
+    new CfnOutput(this, "user-telemetry-api-target-hostname", {
       description: "hostname",
       value: `${telemetryDomainName.domainNameAliasDomainName}`,
     });

--- a/projects/event-api-lambda/artifact.json
+++ b/projects/event-api-lambda/artifact.json
@@ -1,6 +1,6 @@
 {
   "projectName": "Editorial Tools::Telemetry Service event lambda",
-  "vcsURL": "https://github.com/guardian/tools-telemetry-service",
+  "vcsURL": "https://github.com/guardian/editorial-tools-user-telemetry-service",
   "actions": [
     {
       "action": "event-api-lambda",

--- a/projects/event-api-lambda/localstack/buckets.sh
+++ b/projects/event-api-lambda/localstack/buckets.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Create our telemetry bucket for localstack
-awslocal s3 mb s3://telemetry-service
+awslocal s3 mb s3://user-telemetry-service

--- a/projects/event-api-lambda/src/constants.ts
+++ b/projects/event-api-lambda/src/constants.ts
@@ -1,1 +1,1 @@
-export const telemetryBucketName = process.env.TELEMETRY_BUCKET_NAME || 'telemetry-service';
+export const telemetryBucketName = process.env.TELEMETRY_BUCKET_NAME || 'user-telemetry-service';

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -6,7 +6,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR=${DIR}/..
 
 EVENT_API_LAMBDA_DIR="$ROOT_DIR/projects/event-api-lambda"
-EVENT_API_LAMBDA_BUCKET_NAME=telemetry-service
+EVENT_API_LAMBDA_BUCKET_NAME=user-telemetry-service
 
 function setupEventApiLambda {
   cd $EVENT_API_LAMBDA_DIR


### PR DESCRIPTION
## What does this change?

Renames the service to user-telemetry-service. There were a few changes to the name of the service as we discussed its creation, but I think we've landed on that.

## How to test

Everything should work as before. The service is well-covered by integration tests, so passing tests should be a 👍. 