### PR TITLE
Add cors headers

### DIFF
--- a/projects/event-lambdas/src/lib/application.ts
+++ b/projects/event-lambdas/src/lib/application.ts
@@ -8,10 +8,8 @@ export const createApp = (): express.Application => {
   const app = express();
 
   app.use((req, res, next) => {
-    console.log({ url: req.get('origin') });
     const host = req.get('origin') || '';
     if (host.endsWith(".gutools.co.uk") || host.endsWith(".dev-gutools.co.uk")) {
-      console.log("Adding headers");
       res.header("Access-Control-Allow-Headers", "Content-Type");
       res.header("Access-Control-Allow-Origin", req.get('origin'));
       res.header("Access-Control-Allow-Methods", "OPTIONS,POST,GET");

--- a/projects/event-lambdas/src/lib/application.ts
+++ b/projects/event-lambdas/src/lib/application.ts
@@ -15,6 +15,7 @@ export const createApp = (): express.Application => {
       res.header("Access-Control-Allow-Headers", "Content-Type");
       res.header("Access-Control-Allow-Origin", req.get('origin'));
       res.header("Access-Control-Allow-Methods", "OPTIONS,POST,GET");
+      res.header("Access-Control-Allow-Credentials", "true");
     }
     next();
   });

--- a/projects/event-lambdas/src/lib/application.ts
+++ b/projects/event-lambdas/src/lib/application.ts
@@ -7,6 +7,13 @@ import { putEventsIntoS3Bucket, parseEventJson } from "./util";
 export const createApp = (): express.Application => {
   const app = express();
 
+  app.use((_, res, next) => {
+    res.header("Access-Control-Allow-Headers", "Content-Type");
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Methods", "OPTIONS,POST,GET");
+    next();
+  });
+
   app.get("/healthcheck", (_: Request, res: Response) => {
     res.send(createOkResponse("This is the Event API app."));
   });

--- a/projects/event-lambdas/src/lib/application.ts
+++ b/projects/event-lambdas/src/lib/application.ts
@@ -7,10 +7,15 @@ import { putEventsIntoS3Bucket, parseEventJson } from "./util";
 export const createApp = (): express.Application => {
   const app = express();
 
-  app.use((_, res, next) => {
-    res.header("Access-Control-Allow-Headers", "Content-Type");
-    res.header("Access-Control-Allow-Origin", "*");
-    res.header("Access-Control-Allow-Methods", "OPTIONS,POST,GET");
+  app.use((req, res, next) => {
+    console.log({ url: req.get('origin') });
+    const host = req.get('origin') || '';
+    if (host.endsWith(".gutools.co.uk") || host.endsWith(".dev-gutools.co.uk")) {
+      console.log("Adding headers");
+      res.header("Access-Control-Allow-Headers", "Content-Type");
+      res.header("Access-Control-Allow-Origin", req.get('origin'));
+      res.header("Access-Control-Allow-Methods", "OPTIONS,POST,GET");
+    }
     next();
   });
 


### PR DESCRIPTION
## What does this change?

Adds CORS headers for `.gutools.co.uk` addresses, to enable calls to the API from the browser.

## How to test

Make a GET request from a `.gutools.co.uk`. You should see CORS headers in the response that match your domain.

This is sadly only testable in PROD right now – #11 adds a local endpoint that will enable us to test locally. The easiest way to see it working would be to enable Typerighter in production Composer, and run a check. You should see telemetry events submitted from your browser on a 10s interval, and successfully processed with the correct CORS headers.

## How can we measure success?

Users are able to make API requests to this service from valid domains in the browser.