### PR TITLE
Renames telemetry client publish script to deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ To release changes, deploy the `editorial-tools-user-telemetry-service` project 
 
 ## Creating and deploying the package
 
-To create and deploy the associated npm package update the version number and then run `npm publish`.
+To create and deploy the associated npm package update the version number and then run `npm deploy`.

--- a/projects/user-telemetry-client/package.json
+++ b/projects/user-telemetry-client/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test": "jest --env=jsdom",
     "build": "tsc --build",
-    "publish": "npm run test && npm run build && npm publish"
+    "deploy": "npm run test && npm run build && npm publish"
   },
   "devDependencies": {
     "@types/fetch-mock": "^7.3.5",


### PR DESCRIPTION
## What does this change?

This PR renames the telemetry client `publish` script to `deploy` [to avoid a conflict](https://docs.npmjs.com/cli/v8/commands/npm-publish).

