### PR TITLE
feat: Converts boolean "values" to ints

### DIFF
--- a/projects/user-telemetry-client/package.json
+++ b/projects/user-telemetry-client/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "test": "jest --env=jsdom",
-    "build": "tsc --build",
+    "build": "tsc --project tsconfig-build.json",
     "release": "semantic-release"
   },
   "devDependencies": {

--- a/projects/user-telemetry-client/src/TelemetryService.ts
+++ b/projects/user-telemetry-client/src/TelemetryService.ts
@@ -43,7 +43,8 @@ export class UserTelemetryEventSender {
     private throttledSendEvents = throttle(this.sendEvents, this.throttleDelay, { trailing: true, leading: false })
 
     public addEvent(event: IUserTelemetryEvent): void {
-      this.eventBuffer.push(event);
+      const value = + event.value 
+      this.eventBuffer.push({ ...event, value });
       this.throttledSendEvents();
     }
 

--- a/projects/user-telemetry-client/tsconfig-build.json
+++ b/projects/user-telemetry-client/tsconfig-build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "tests/**"
+  ]
+}

--- a/projects/user-telemetry-client/tsconfig.json
+++ b/projects/user-telemetry-client/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "include": ["src/**/*", "../definitions/**/*"],
   "compilerOptions": {
     "target": "ES2019",
     "module": "commonjs",


### PR DESCRIPTION
## What does this change?

This PR updates the user-telemetry-client to convert boolean values into integers. This is beneficial because it ensures values are aggregatable by elastic search.

## How to test

I have written tests to cover this case, to be thorough we could also link the package locally to a repo which consumes i.e. Composer.

## How can we measure success?

The telemetry client is nice and simple, additionally values are aggregatable within ELK. 

