### PR TITLE
Partition events in S3 by app/stage/type

### DIFF
--- a/projects/event-lambdas/src/event-api-lambda/__tests__/api-lambda.spec.ts
+++ b/projects/event-lambdas/src/event-api-lambda/__tests__/api-lambda.spec.ts
@@ -266,7 +266,7 @@ describe("Event API lambda", () => {
         .send(request);
 
       const expectedResponse = {
-        message: "data/2023-05-16/2023-05-16T10:36:38.000Z-mock-uuid",
+        message: "data/example-app/PROD/USER_ACTION_1/2023-05-16/2023-05-16T10:36:38.000Z-mock-uuid",
         status: "ok",
       };
 

--- a/projects/event-lambdas/src/event-api-lambda/application.ts
+++ b/projects/event-lambdas/src/event-api-lambda/application.ts
@@ -59,7 +59,7 @@ export const createApp = (initConfig: AppConfig): express.Application => {
             `Added ${maybeEventData.value.length} telemetry event(s) to S3 at key ${fileKey}`
           );
 
-          applyOkResponse(res, 201, fileKey);
+          applyOkResponse(res, 201, fileKey.join(","));
         }
       )
   );

--- a/projects/event-lambdas/src/event-api-lambda/index.ts
+++ b/projects/event-lambdas/src/event-api-lambda/index.ts
@@ -22,7 +22,7 @@ export type AppConfig = {
 // Runs during the Lambda initialisation phase
 // See https://docs.aws.amazon.com/lambda/latest/operatorguide/static-initialization.html
 async function initialise(): Promise<AppConfig> {
-  console.log("Running initialisation phase")
+  console.log("Running initialisation phase");
 
   // Get valid secrets for the HMAC key
   const validSecrets = await getValidSecrets(hmacSecretLocation);
@@ -53,7 +53,7 @@ async function initialise(): Promise<AppConfig> {
 const appConfig = initialise();
 
 export const handler: Handler = async (event, context) => {
-  console.log("Lambda handler called, processing request.")
+  console.log("Lambda handler called, processing request.");
 
   const app = createApp(await appConfig);
 
@@ -61,7 +61,7 @@ export const handler: Handler = async (event, context) => {
     awsServerlessExpress.createServer(app),
     event,
     context,
-    'PROMISE'
+    "PROMISE"
   ).promise;
 };
 

--- a/projects/event-lambdas/src/event-s3-lambda/__tests__/s3-event-lambda.spec.ts
+++ b/projects/event-lambdas/src/event-s3-lambda/__tests__/s3-event-lambda.spec.ts
@@ -44,13 +44,13 @@ describe("s3 event handler", () => {
   });
 
   it("should read s3 files from the given event, and reject them if they're malformed", async () => {
-    const Key = await putEventsIntoS3Bucket([{ object: "is-invalid" }] as any, "example-key");
+    const keys = await putEventsIntoS3Bucket([{ object: "is-invalid" }] as any, "example-key");
 
-    const event = getApiGatewayEventForPutEvent(telemetryBucketName, Key);
+    const event = getApiGatewayEventForPutEvent(telemetryBucketName, keys[0]);
     const lambdaResponse = await handler(event);
 
     const expectedResponse = JSON.stringify(
-      createErrorResponse(`Invalid data in file with key ${Key}`, [
+      createErrorResponse(`Invalid data in file with key ${keys[0]}`, [
         {
           keyword: "required",
           dataPath: "[0]",

--- a/projects/event-lambdas/src/lib/__tests__/utils.spec.ts
+++ b/projects/event-lambdas/src/lib/__tests__/utils.spec.ts
@@ -1,6 +1,17 @@
 import { IUserTelemetryEvent } from "../../../../definitions/IUserTelemetryEvent";
-import { convertEventsToNDJSON, convertNDJSONToEvents } from "../util";
+import {
+  convertEventsToNDJSON,
+  convertNDJSONToEvents,
+  putEventsIntoS3Bucket,
+} from "../util";
 import { events, eventsAsNDJSON } from "../../__tests__/fixtures";
+import MockDate from "mockdate";
+import { s3 } from "../../lib/aws";
+import { telemetryBucketName } from "../../lib/constants";
+
+jest.mock("uuid", () => ({
+  v4: () => "mock-uuid",
+}));
 
 describe("utils", () => {
   describe("NDJSON conversion", () => {
@@ -13,6 +24,134 @@ describe("utils", () => {
       it("should convert an NDJSON string to an array of event data", () => {
         expect(convertNDJSONToEvents(eventsAsNDJSON)).toEqual(events);
       });
+    });
+  });
+
+  describe("putEventsIntoS3Bucket", () => {
+    const constantDate = "Tue, 16 May 2023 10:36:38 GMT";
+
+    const testCases = [
+      {
+        appEvents: [
+          {
+            app: "app-1",
+            stage: "CODE",
+            type: "USER_ACTION_1",
+            value: 1,
+            eventTime: "2020-09-03T07:51:27.669Z",
+          },
+          {
+            app: "app-1",
+            stage: "CODE",
+            type: "USER_ACTION_1",
+            value: 2,
+            eventTime: "2020-09-03T07:51:27.669Z",
+          },
+        ],
+        expectedLocation:
+          "data/app-1/CODE/USER_ACTION_1/2023-05-16/2023-05-16T10:36:38.000Z-mock-uuid",
+      },
+      {
+        appEvents: [
+          {
+            app: "app-2",
+            stage: "PROD",
+            type: "USER_ACTION_2",
+            value: 1,
+            eventTime: "2020-09-03T07:51:27.669Z",
+          },
+        ],
+        expectedLocation:
+          "data/app-2/PROD/USER_ACTION_2/2023-05-16/2023-05-16T10:36:38.000Z-mock-uuid",
+      },
+      {
+        appEvents: [
+          {
+            app: "",
+            stage: "",
+            type: "",
+            value: 1,
+            eventTime: "2020-09-03T07:51:27.669Z",
+          },
+        ],
+        expectedLocation:
+          "data/UNDEFINED/UNDEFINED/UNDEFINED/2023-05-16/2023-05-16T10:36:38.000Z-mock-uuid",
+      },
+    ];
+
+    beforeAll(() => {
+      MockDate.set(constantDate);
+    });
+
+    const listDataObjects = async () => {
+      const dataListing = await s3.listObjects({Bucket: telemetryBucketName, Prefix: 'data'}).promise();
+      return (dataListing.Contents ?? []).map(({Key}) => Key as string)
+    }
+
+    beforeEach(async () => {
+      // Clear S3 objects
+      const dataObjects = await listDataObjects();
+
+      await Promise.all(dataObjects.map(async (objectLocation) => {
+        await s3.deleteObject({
+          Bucket: telemetryBucketName,
+          Key: objectLocation,
+        }).promise();
+      }))
+    });
+
+    it("writes the expected data to the expected locations", async () => {
+      const testExpectations: {
+        events: IUserTelemetryEvent[];
+        locations: {
+          expectedLocation: string;
+          expectedContents: string;
+        }[];
+      } = testCases.reduce(
+        (acc, { appEvents, expectedLocation }) => {
+          const expectedContents = convertEventsToNDJSON(appEvents);
+
+          return {
+            events: acc.events.concat(appEvents),
+            locations: acc.locations.concat([
+              { expectedLocation, expectedContents },
+            ]),
+          };
+        },
+        {
+          events: [] as IUserTelemetryEvent[],
+          locations: [] as {
+            expectedLocation: string;
+            expectedContents: string;
+          }[],
+        }
+      );
+
+      const locationsWritten = await putEventsIntoS3Bucket(testExpectations.events);
+      const expectedLocations = testExpectations.locations.map((l) => l.expectedLocation);
+
+      // Check the function returns the expected paths
+      expect(locationsWritten).toEqual(expectedLocations);
+
+      // Check the locations stated exist and have the expected data
+      await Promise.all(testExpectations.locations.map(async ({expectedLocation, expectedContents}) => {
+        const writtenFile = await s3
+        .getObject({
+          Bucket: telemetryBucketName,
+          Key: expectedLocation,
+        })
+        .promise();
+
+        await expect(writtenFile.Body?.toString()).toBe(expectedContents);
+      }));
+
+      // Check we have only the expected files
+      const dataObjects = await listDataObjects();
+      expect(dataObjects.sort()).toEqual(expectedLocations.sort());
+    });
+
+    afterAll(() => {
+      MockDate.reset();
     });
   });
 });


### PR DESCRIPTION
## What does this change?

This change updates the `event-api-lambda` to include app/stage/type in the path written to S3, which will make it easy to universally clean up one source if starts misbehaving.

The concern is with multiple users what is sent is less tightly controlled and this gives us a way to quickly fix things if there is a misbehaving client that sends PII.

`event-s3-lambda` should not be impacted as the path is not used when events are handed to kinesis.

Depends on https://github.com/guardian/editorial-tools-user-telemetry-service/pull/24

## How to test

You can run start the event-lambdas locally, `npm run start`, and query the API locally using [this script](https://gist.github.com/kenoir/1a8ba8f970b36d5f0dd9e646f222153c0). The application will log the written paths.

For example: 
```
{"status":"ok","message":"data/example-app/CODE/KENNY_ACTION_1/2023-05-19/2023-05-19T13:59:15.950Z-4381bd59-6c5e-454a-9688-b0edd9431024"}
```

## How can we measure success?

Improved protection against accidents involving PII being stored unintentionally, and more human readable and machine traversable data stored in S3. 

## Have we considered potential risks?

This will change the storage location for all data stored (including from existing systems), does this jeopardise any existing processes?