### PR TITLE
set reserved concurrency on telemetry lambdas

### DIFF
--- a/cdk/lib/__snapshots__/telemetry-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/telemetry-stack.test.ts.snap
@@ -417,6 +417,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "FunctionName": "event-api-lambda-CODE",
         "Handler": "index.handler",
         "MemorySize": 128,
+        "ReservedConcurrentExecutions": 5,
         "Role": {
           "Fn::GetAtt": [
             "EventApiLambdaServiceRole3695319B",
@@ -689,6 +690,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "FunctionName": "event-s3-lambda-CODE",
         "Handler": "index.handler",
         "MemorySize": 128,
+        "ReservedConcurrentExecutions": 5,
         "Role": {
           "Fn::GetAtt": [
             "EventS3LambdaServiceRole34104ADE",

--- a/cdk/lib/telemetry-stack.ts
+++ b/cdk/lib/telemetry-stack.ts
@@ -14,6 +14,7 @@ import {
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { Effect, PolicyDocument, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Stream } from 'aws-cdk-lib/aws-kinesis';
+import type { FunctionProps } from 'aws-cdk-lib/aws-lambda';
 import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Bucket, EventType } from 'aws-cdk-lib/aws-s3';
 import { LambdaDestination } from 'aws-cdk-lib/aws-s3-notifications';
@@ -87,7 +88,7 @@ export class TelemetryStack extends GuStack {
 			'composer-dist',
 		);
 
-		const commonLambdaParams = {
+		const commonLambdaParams: Omit<FunctionProps, 'code'> = {
 			runtime: Runtime.NODEJS_14_X,
 			memorySize: 128,
 			timeout: Duration.seconds(5),
@@ -101,6 +102,7 @@ export class TelemetryStack extends GuStack {
 				TELEMETRY_BUCKET_NAME: telemetryDataBucket.bucketName,
 				HMAC_SECRET_LOCATION: hmacSecret.secretName,
 			},
+			reservedConcurrentExecutions: 5,
 		};
 
 		/**


### PR DESCRIPTION
## What does this change?

to avoid any chance that over-sending of telemetry would impact other lambdas in this account

requires #24 
