### PR TITLE
Allow 5 minute window for HMAC tokens, rather than 5 seconds

### DIFF
--- a/projects/event-lambdas/src/lib/__tests__/panda-hmac.spec.ts
+++ b/projects/event-lambdas/src/lib/__tests__/panda-hmac.spec.ts
@@ -5,7 +5,7 @@ import MockDate from "mockdate";
 describe("panda-hmac", () => {
   const constantDate = "Tue, 16 May 2023 10:36:38 GMT";
   const requestPath = "/example/path";
-  const hmacAllowedDateOffsetInMillis = 5000;
+  const hmacAllowedDateOffsetInMillis = 300000;
   const pandaHmac = new PandaHmacAuthentication(hmacAllowedDateOffsetInMillis, [
     "changeme",
   ]);
@@ -56,7 +56,7 @@ describe("panda-hmac", () => {
     });
     it("fails to verify a token outside the allowed time window", () => {
       const requestDateOutsideWindow = new Date(
-        Date.parse(constantDate) + 5000
+        Date.parse(constantDate) + 300000
       ).toUTCString();
 
       const expectedRequestToken =

--- a/projects/event-lambdas/src/lib/constants.ts
+++ b/projects/event-lambdas/src/lib/constants.ts
@@ -7,4 +7,4 @@ export const pandaSettingsKey =
 export const hmacSecretLocation =
   process.env.HMAC_SECRET_LOCATION ||
   "/DEV/flexible/user-telemetry-service/hmacSecret";
-export const hmacAllowedDateOffsetInMillis = 5000;
+export const hmacAllowedDateOffsetInMillis = 300000;

--- a/projects/event-lambdas/src/lib/panda-hmac.ts
+++ b/projects/event-lambdas/src/lib/panda-hmac.ts
@@ -42,7 +42,9 @@ export class PandaHmacAuthentication {
   verify(requestDate: string, path: string, requestToken: string): boolean {
     return this.hmacSecretKeys.some(
       (secretKey) =>
+        // Is the date in the header within the allowable range?
         isDateValid(this.hmacAllowedDateOffsetInMillis, requestDate) &&
+        // Check the HMAC head
         isHMACValid(secretKey, requestDate, path, requestToken)
     );
   }


### PR DESCRIPTION
## What does this change?

This changes the time window that HMAC tokens are valid for from 5 seconds to 5 minutes. Some of the editorial machines using this mechanism suffer relatively significant time drift, _and_ this brings the implementation of HMAC authentication in line with [our scala lib](https://github.com/guardian/hmac-headers/blob/main/src/main/scala/com/gu/hmac/HMACHeaders.scala).

## How to test

Run the tests! Deploy the change to CODE and test this behaves as expected.

## How can we measure success?

TBD

## Have we considered potential risks?

TBD