### PR TITLE
Allow use on https://www.theguardian.com

### DIFF
--- a/projects/event-lambdas/src/event-api-lambda/application.ts
+++ b/projects/event-lambdas/src/event-api-lambda/application.ts
@@ -13,7 +13,8 @@ export const createApp = (initConfig: AppConfig): express.Application => {
     const host = req.get("origin") || "";
     if (
       host.endsWith(".gutools.co.uk") ||
-      host.endsWith(".dev-gutools.co.uk")
+      host.endsWith(".dev-gutools.co.uk") ||
+      host === "https://www.theguardian.com" // for use with Ophan Heatmap (a.k.a. Heatphan)
     ) {
       res.header("Access-Control-Allow-Headers", "Content-Type");
       res.header("Access-Control-Allow-Origin", req.get("origin"));


### PR DESCRIPTION
[Ophan Heatmap (a.k.a. Heatphan)](https://github.com/guardian/ophan/pull/5811) runs on https://www.theguardian.com and needs to send telemetry events. 

Paired with @jonflynng 