### PR TITLE
Allow Ophan HMAC secret key access

### DIFF
--- a/cdk/lib/__snapshots__/telemetry-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/telemetry-stack.test.ts.snap
@@ -311,6 +311,40 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
     },
+    "EventApiHmacSecretPolicyC8C3661F": {
+      "Properties": {
+        "ResourcePolicy": {
+          "Statement": [
+            {
+              "Action": "secretsmanager:GetSecretValue",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":iam::021353022223:root",
+                    ],
+                  ],
+                },
+              },
+              "Resource": {
+                "Ref": "EventApiHmacSecret1C59BAF9",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "SecretId": {
+          "Ref": "EventApiHmacSecret1C59BAF9",
+        },
+      },
+      "Type": "AWS::SecretsManager::ResourcePolicy",
+    },
     "EventApiLambda6AA4ADA7": {
       "DependsOn": [
         "EventApiLambdaServiceRoleDefaultPolicy92CD0566",

--- a/cdk/lib/telemetry-stack.ts
+++ b/cdk/lib/telemetry-stack.ts
@@ -73,7 +73,7 @@ export class TelemetryStack extends GuStack {
 
 		const allowOphanAccessToHmac = new PolicyStatement({
 			effect: Effect.ALLOW,
-			principals: [new AccountPrincipal(GuardianAwsAccounts)],
+			principals: [new AccountPrincipal(GuardianAwsAccounts.Ophan)],
 			actions: ['secretsmanager:GetSecretValue'],
 			resources: [hmacSecret.secretArn],
 		});

--- a/cdk/lib/telemetry-stack.ts
+++ b/cdk/lib/telemetry-stack.ts
@@ -73,7 +73,7 @@ export class TelemetryStack extends GuStack {
 
 		const allowOphanAccessToHmac = new PolicyStatement({
 			effect: Effect.ALLOW,
-			principals: [new AccountPrincipal(`arn:aws:iam::${GuardianAwsAccounts.Ophan}:role/dashboardec2rolename`)],
+			principals: [new AccountPrincipal(GuardianAwsAccounts)],
 			actions: ['secretsmanager:GetSecretValue'],
 			resources: [hmacSecret.secretArn],
 		});

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8295,7 +8295,7 @@
     "@guardian/private-infrastructure-config": {
       "version": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#5242448b2aabea0e5d7c1729d49113709428f5b3",
       "dev": true,
-      "from": "@guardian/private-infrastructure-config@git+ssh://git@github.com:guardian/private-infrastructure-config.git#v2.4.0"
+      "from": "@guardian/private-infrastructure-config@github:guardian/private-infrastructure-config#v2.4.0"
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -11,6 +11,7 @@
         "@guardian/cdk": "50.5.0",
         "@guardian/eslint-config-typescript": "5.0.0",
         "@guardian/prettier": "3.0.0",
+        "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.4.0",
         "@types/jest": "^29.5.1",
         "@types/node": "18.13.0",
         "aws-cdk": "2.77.0",
@@ -791,6 +792,11 @@
         "prettier": "^2.4.0",
         "tslib": "^2.4.1"
       }
+    },
+    "node_modules/@guardian/private-infrastructure-config": {
+      "version": "2.3.0",
+      "resolved": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#5242448b2aabea0e5d7c1729d49113709428f5b3",
+      "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -8285,6 +8291,11 @@
       "integrity": "sha512-o1g0tYVniUNFxWoCp3DbK33gTebDmvYORN6oeV+lXvqa9YyhslswzGkmV0mSRErXmla0H+pIlnfF0Ve7fb0Mfw==",
       "dev": true,
       "requires": {}
+    },
+    "@guardian/private-infrastructure-config": {
+      "version": "git+ssh://git@github.com/guardian/private-infrastructure-config.git#5242448b2aabea0e5d7c1729d49113709428f5b3",
+      "dev": true,
+      "from": "@guardian/private-infrastructure-config@git+ssh://git@github.com:guardian/private-infrastructure-config.git#v2.4.0"
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.8",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -18,6 +18,7 @@
     "@guardian/cdk": "50.5.0",
     "@guardian/eslint-config-typescript": "5.0.0",
     "@guardian/prettier": "3.0.0",
+    "@guardian/private-infrastructure-config": "github:guardian/private-infrastructure-config#v2.4.0",
     "@types/jest": "^29.5.1",
     "@types/node": "18.13.0",
     "aws-cdk": "2.77.0",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Creates a new policy in attempt to allow Ophan to access Telemetry's HMAC shared secret key. The policy is not set to give permissions to defined role and rather for the entire Ophan account.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
