### PR TITLE
Revert "Allow use on https://www.theguardian.com"

### DIFF
--- a/projects/event-lambdas/src/event-api-lambda/application.ts
+++ b/projects/event-lambdas/src/event-api-lambda/application.ts
@@ -13,8 +13,7 @@ export const createApp = (initConfig: AppConfig): express.Application => {
     const host = req.get("origin") || "";
     if (
       host.endsWith(".gutools.co.uk") ||
-      host.endsWith(".dev-gutools.co.uk") ||
-      host === "https://www.theguardian.com" // for use with Ophan Heatmap (a.k.a. Heatphan)
+      host.endsWith(".dev-gutools.co.uk")
     ) {
       res.header("Access-Control-Allow-Headers", "Content-Type");
       res.header("Access-Control-Allow-Origin", req.get("origin"));


### PR DESCRIPTION
For other auth reasons ophan needs to proxy telemetry (see #34, #35 and https://github.com/guardian/ophan/pull/5839) so the change in https://github.com/guardian/editorial-tools-user-telemetry-service/pull/33 really ought to be reverted.