### PR TITLE
increase concurrent executions limit for `event-api-lambda` since we're seeing throttling

### DIFF
--- a/cdk/lib/__snapshots__/telemetry-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/telemetry-stack.test.ts.snap
@@ -413,7 +413,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "FunctionName": "event-api-lambda-CODE",
         "Handler": "index.handler",
         "MemorySize": 128,
-        "ReservedConcurrentExecutions": 5,
+        "ReservedConcurrentExecutions": 15,
         "Role": {
           "Fn::GetAtt": [
             "EventApiLambdaServiceRole3695319B",
@@ -686,7 +686,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "FunctionName": "event-s3-lambda-CODE",
         "Handler": "index.handler",
         "MemorySize": 128,
-        "ReservedConcurrentExecutions": 5,
+        "ReservedConcurrentExecutions": 15,
         "Role": {
           "Fn::GetAtt": [
             "EventS3LambdaServiceRole34104ADE",

--- a/cdk/lib/telemetry-stack.ts
+++ b/cdk/lib/telemetry-stack.ts
@@ -132,7 +132,7 @@ export class TelemetryStack extends GuStack {
 				TELEMETRY_BUCKET_NAME: telemetryDataBucket.bucketName,
 				HMAC_SECRET_LOCATION: hmacSecret.secretName,
 			},
-			reservedConcurrentExecutions: 5,
+			reservedConcurrentExecutions: 15,
 		};
 
 		/**


### PR DESCRIPTION
Since Ophan's Heatphan started sending metrics (see #34 and https://github.com/guardian/ophan/pull/5839) they've been getting 5XXs in their telemetry proxy, which as we can see from these API Gateway metrics are originating from the telemetry service...
<img width="1427" alt="image" src="https://github.com/guardian/editorial-tools-user-telemetry-service/assets/19289579/9b1a9adc-4322-43e8-8a80-9167baa8fd03">
... looking at the corresponding lambda metrics we see a huge increase in throttling...
<img width="1424" alt="image" src="https://github.com/guardian/editorial-tools-user-telemetry-service/assets/19289579/e298c02f-a975-4b09-abdb-2993427103af">
... based on the time of day these occur and the fact majority of requests succeed that perhaps owing to the extra latency with Australia 🦘 eveything is taking that bit longer and making concurrent execution much more likely.

This PR seeks to address that by increasing the concurrency limit from a meagre 5 up to a lofty 15 (which is still a small portion of the account wide concurrency limit of 1,000).