### PR TITLE
Make OPTIONS responses cacheable

### DIFF
--- a/projects/event-lambdas/src/event-api-lambda/application.ts
+++ b/projects/event-lambdas/src/event-api-lambda/application.ts
@@ -20,7 +20,13 @@ export const createApp = (initConfig: AppConfig): express.Application => {
       res.header("Access-Control-Allow-Methods", "OPTIONS,POST,GET");
       res.header("Access-Control-Allow-Credentials", "true");
     }
-    next();
+    if (req.method === "OPTIONS") {
+      res.header("Vary", "Origin")
+      res.header("Cache-control", "max-age=600")
+      res.send(200);
+    } else {
+      next();
+    }
   });
 
   app.get("/healthcheck", (_: Request, res: Response) => {

--- a/projects/event-lambdas/src/event-api-lambda/application.ts
+++ b/projects/event-lambdas/src/event-api-lambda/application.ts
@@ -19,14 +19,9 @@ export const createApp = (initConfig: AppConfig): express.Application => {
       res.header("Access-Control-Allow-Origin", req.get("origin"));
       res.header("Access-Control-Allow-Methods", "OPTIONS,POST,GET");
       res.header("Access-Control-Allow-Credentials", "true");
+      res.header("Access-Control-Max-Age", "86400");
     }
-    if (req.method === "OPTIONS") {
-      res.header("Vary", "Origin")
-      res.header("Cache-control", "max-age=600")
-      res.send(200);
-    } else {
-      next();
-    }
+    next();
   });
 
   app.get("/healthcheck", (_: Request, res: Response) => {


### PR DESCRIPTION
## What does this change?

Adds a `Access-Control-Max-Age` header to let the browser know that the OPTIONS/CORs response can be relied upon for 24 hours. This should halve the number of requests going to the user telemetry service