### PR TITLE
Newer AWS Lambda Node runtime does not include aws-sdk

### DIFF
--- a/projects/event-lambdas/package.json
+++ b/projects/event-lambdas/package.json
@@ -23,7 +23,7 @@
     "typescript": "^3.5.3"
   },
   "scripts": {
-    "build": "ncc build src/event-api-lambda/index.ts -o dist/event-api-lambda -m -e aws-sdk && ncc build src/event-s3-lambda/index.ts -o dist/event-s3-lambda -m -e aws-sdk",
+    "build": "ncc build src/event-api-lambda/index.ts -o dist/event-api-lambda -m && ncc build src/event-s3-lambda/index.ts -o dist/event-s3-lambda -m",
     "start": "ts-node-dev --ignore-watch node_modules src/event-api-lambda/index.ts",
     "test": "JEST_CIRCUS=1 jest --coverage",
     "test:watch": "JEST_CIRCUS=1 jest --watch",


### PR DESCRIPTION
## What does this change?

Should fix error `Runtime.ImportModuleError` introduced by https://github.com/guardian/editorial-tools-user-telemetry-service/pull/42.

`ncc` was configured to expect `aws-sdk` to be provided externally rather than being bundled. AWS Lambda runtimes stopped providing this library from `nodejs18.x` onwards.