### PR TITLE
lambda and step-function for rebuilding ELK index from S3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,10 @@ jobs:
         working-directory: projects/event-lambdas/dist
         run: zip -r -j event-s3-lambda.zip event-s3-lambda/*
 
+      - name: prepare the redrive-from-S3-lambda zip
+        working-directory: projects/event-lambdas/dist
+        run: zip -r -j redrive-from-S3-lambda.zip redrive-from-S3-lambda/*
+
       - uses: guardian/actions-riff-raff@v2
         with:
           projectName: Editorial Tools::Telemetry Service event lambda
@@ -90,3 +94,5 @@ jobs:
               - projects/event-lambdas/dist/event-api-lambda.zip
             event-s3-lambda:
               - projects/event-lambdas/dist/event-s3-lambda.zip
+            user-telemetry-redrive-from-s3-lambda:
+              - projects/event-lambdas/dist/redrive-from-S3-lambda.zip

--- a/cdk/bin/__snapshots__/cdk.test.ts.snap
+++ b/cdk/bin/__snapshots__/cdk.test.ts.snap
@@ -5,6 +5,20 @@ exports[`The riff-raff output YAML matches the snapshot 1`] = `
   - PROD
   - CODE
 deployments:
+  lambda-upload-eu-west-1-flexible-user-telemetry-redrive-from-s3-lambda:
+    type: aws-lambda
+    stacks:
+      - flexible
+    regions:
+      - eu-west-1
+    app: user-telemetry-redrive-from-s3-lambda
+    contentDirectory: user-telemetry-redrive-from-s3-lambda
+    parameters:
+      bucketSsmLookup: true
+      lookupByTags: true
+      fileName: redrive-from-S3-lambda.zip
+    actions:
+      - uploadLambda
   cfn-eu-west-1-flexible-telemetry-stack:
     type: cloud-formation
     regions:
@@ -17,6 +31,24 @@ deployments:
       templateStagePaths:
         PROD: TelemetryStackPROD.template.json
         CODE: TelemetryStackCODE.template.json
+    dependencies:
+      - lambda-upload-eu-west-1-flexible-user-telemetry-redrive-from-s3-lambda
+  lambda-update-eu-west-1-flexible-user-telemetry-redrive-from-s3-lambda:
+    type: aws-lambda
+    stacks:
+      - flexible
+    regions:
+      - eu-west-1
+    app: user-telemetry-redrive-from-s3-lambda
+    contentDirectory: user-telemetry-redrive-from-s3-lambda
+    parameters:
+      bucketSsmLookup: true
+      lookupByTags: true
+      fileName: redrive-from-S3-lambda.zip
+    actions:
+      - updateLambda
+    dependencies:
+      - cfn-eu-west-1-flexible-telemetry-stack
   event-api-lambda:
     type: aws-lambda
     app: event-api-lambda

--- a/cdk/lib/__snapshots__/telemetry-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/telemetry-stack.test.ts.snap
@@ -7,6 +7,8 @@ exports[`The telemetry stack matches the snapshot 1`] = `
       "GuStringParameter",
       "GuRole",
       "GuCname",
+      "GuDistributionBucketParameter",
+      "GuLambdaFunction",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -51,6 +53,11 @@ exports[`The telemetry stack matches the snapshot 1`] = `
     "Cert": {
       "Description": "Certificate ARN for telemetry endpoint",
       "Type": "String",
+    },
+    "DistributionBucketName": {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "Hostname": {
       "Description": "Hostname for telemetry endpoint",
@@ -833,6 +840,508 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "Roles": [
           {
             "Ref": "EventS3LambdaServiceRole34104ADE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ReDriveFromS3Lambda459381EC": {
+      "DependsOn": [
+        "ReDriveFromS3LambdaServiceRoleDefaultPolicy1E561F36",
+        "ReDriveFromS3LambdaServiceRole810C3013",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "flexible/CODE/user-telemetry-redrive-from-s3-lambda/redrive-from-S3-lambda.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "user-telemetry-redrive-from-s3-lambda",
+            "HMAC_SECRET_LOCATION": {
+              "Fn::Join": [
+                "-",
+                [
+                  {
+                    "Fn::Select": [
+                      0,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "EventApiHmacSecret1C59BAF9",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      1,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "EventApiHmacSecret1C59BAF9",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      2,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "EventApiHmacSecret1C59BAF9",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+            "LOG_ENDPOINT_ENABLED": "true",
+            "MAX_LOG_SIZE": {
+              "Ref": "MaxLogSize",
+            },
+            "STACK": "flexible",
+            "STAGE": "CODE",
+            "TELEMETRY_BUCKET_NAME": {
+              "Ref": "BucketName",
+            },
+            "TELEMETRY_STREAM_NAME": {
+              "Fn::Select": [
+                1,
+                {
+                  "Fn::Split": [
+                    "/",
+                    {
+                      "Fn::Select": [
+                        5,
+                        {
+                          "Fn::Split": [
+                            ":",
+                            {
+                              "Ref": "KinesisArn",
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+        "FunctionName": "flexible-CODE-user-telemetry-redrive-from-s3-lambda",
+        "Handler": "index.handler",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+        },
+        "MemorySize": 1024,
+        "ReservedConcurrentExecutions": 1,
+        "Role": {
+          "Fn::GetAtt": [
+            "ReDriveFromS3LambdaServiceRole810C3013",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "user-telemetry-redrive-from-s3-lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/editorial-tools-user-telemetry-service",
+          },
+          {
+            "Key": "Stack",
+            "Value": "flexible",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "ReDriveFromS3LambdaServiceRole810C3013": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "user-telemetry-redrive-from-s3-lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/editorial-tools-user-telemetry-service",
+          },
+          {
+            "Key": "Stack",
+            "Value": "flexible",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ReDriveFromS3LambdaServiceRoleDefaultPolicy1E561F36": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/flexible/CODE/user-telemetry-redrive-from-s3-lambda/redrive-from-S3-lambda.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/flexible/user-telemetry-redrive-from-s3-lambda",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/CODE/flexible/user-telemetry-redrive-from-s3-lambda/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "BucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "BucketName",
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": [
+                "kinesis:ListShards",
+                "kinesis:PutRecord",
+                "kinesis:PutRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "KinesisArn",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ReDriveFromS3LambdaServiceRoleDefaultPolicy1E561F36",
+        "Roles": [
+          {
+            "Ref": "ReDriveFromS3LambdaServiceRole810C3013",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "ReDriveFromS3StepFunctionA89D6BF5": {
+      "DeletionPolicy": "Delete",
+      "DependsOn": [
+        "ReDriveFromS3StepFunctionRoleDefaultPolicy4484140F",
+        "ReDriveFromS3StepFunctionRole110639E1",
+      ],
+      "Properties": {
+        "DefinitionString": {
+          "Fn::Join": [
+            "",
+            [
+              "{"StartAt":"ReDriveFromS3StepFunctionLambdaCall","States":{"ReDriveFromS3StepFunctionLambdaCall":{"Next":"ReDriveFromS3StepFunctionIsDoneChoice","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","Resource":"arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":states:::lambda:invoke","Parameters":{"FunctionName":"",
+              {
+                "Fn::GetAtt": [
+                  "ReDriveFromS3Lambda459381EC",
+                  "Arn",
+                ],
+              },
+              "","Payload.$":"$"}},"ReDriveFromS3StepFunctionIsDoneChoice":{"Type":"Choice","Choices":[{"Variable":"$.Payload","IsNull":false,"Next":"ReDriveFromS3StepFunctionLambdaCall"}],"Default":"ReDriveFromS3StepFunctionIsDone"},"ReDriveFromS3StepFunctionIsDone":{"Type":"Pass","End":true}}}",
+            ],
+          ],
+        },
+        "RoleArn": {
+          "Fn::GetAtt": [
+            "ReDriveFromS3StepFunctionRole110639E1",
+            "Arn",
+          ],
+        },
+        "StateMachineName": "flexible-CODE-user-telemetry-redrive-from-s3-step-function",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/editorial-tools-user-telemetry-service",
+          },
+          {
+            "Key": "Stack",
+            "Value": "flexible",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::StepFunctions::StateMachine",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "ReDriveFromS3StepFunctionRole110639E1": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "states.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/editorial-tools-user-telemetry-service",
+          },
+          {
+            "Key": "Stack",
+            "Value": "flexible",
+          },
+          {
+            "Key": "Stage",
+            "Value": "CODE",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "ReDriveFromS3StepFunctionRoleDefaultPolicy4484140F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "lambda:InvokeFunction",
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "ReDriveFromS3Lambda459381EC",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "ReDriveFromS3Lambda459381EC",
+                          "Arn",
+                        ],
+                      },
+                      ":*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ReDriveFromS3StepFunctionRoleDefaultPolicy4484140F",
+        "Roles": [
+          {
+            "Ref": "ReDriveFromS3StepFunctionRole110639E1",
           },
         ],
       },

--- a/cdk/lib/__snapshots__/telemetry-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/telemetry-stack.test.ts.snap
@@ -1203,6 +1203,17 @@ def submit_response(event: dict, context, response_status: str, error_message: s
                 "Ref": "KinesisArn",
               },
             },
+            {
+              "Action": [
+                "kinesis:UpdateShardCount",
+                "kinesis:DescribeStream",
+                "kinesis:ListShards",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "KinesisArn",
+              },
+            },
           ],
           "Version": "2012-10-17",
         },

--- a/cdk/lib/telemetry-stack.ts
+++ b/cdk/lib/telemetry-stack.ts
@@ -2,6 +2,7 @@ import { GuStack, GuStringParameter } from '@guardian/cdk/lib/constructs/core';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuRole } from '@guardian/cdk/lib/constructs/iam';
+import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import type { App } from 'aws-cdk-lib';
 import { CfnOutput, CfnParameter, Duration, Tags } from 'aws-cdk-lib';
 import {
@@ -18,10 +19,18 @@ import {
 } from 'aws-cdk-lib/aws-iam';
 import { Stream } from 'aws-cdk-lib/aws-kinesis';
 import type { FunctionProps } from 'aws-cdk-lib/aws-lambda';
-import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Code, Function, LoggingFormat, Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Bucket, EventType } from 'aws-cdk-lib/aws-s3';
 import { LambdaDestination } from 'aws-cdk-lib/aws-s3-notifications';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
+import {
+	Choice,
+	Condition,
+	DefinitionBody,
+	Pass,
+	StateMachine,
+} from 'aws-cdk-lib/aws-stepfunctions';
+import { LambdaInvoke } from 'aws-cdk-lib/aws-stepfunctions-tasks';
 
 export class TelemetryStack extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
@@ -277,6 +286,51 @@ export class TelemetryStack extends GuStack {
 			app: 'user-telemetry-service',
 			resourceRecord: telemetryDomainName.domainNameAliasDomainName,
 			ttl: Duration.seconds(3600),
+		});
+
+		/**
+		 * Re-drive lambda and step-function
+		 */
+
+		const reDriveFromS3Lambda = new GuLambdaFunction(
+			this,
+			'ReDriveFromS3Lambda',
+			{
+				app: `${appName}-redrive-from-s3-lambda`,
+				functionName: `${this.stack}-${this.stage}-${appName}-redrive-from-s3-lambda`,
+				...commonLambdaParams,
+				environment: {
+					...commonLambdaParams.environment,
+					TELEMETRY_STREAM_NAME: kinesisStream.streamName,
+				},
+				memorySize: 1024,
+				timeout: Duration.minutes(15), // maximum allowed by AWS
+				reservedConcurrentExecutions: 1,
+				fileName: 'redrive-from-S3-lambda.zip',
+				loggingFormat: LoggingFormat.TEXT,
+			},
+		);
+
+		telemetryDataBucket.grantRead(reDriveFromS3Lambda);
+		kinesisStream.grantWrite(reDriveFromS3Lambda);
+
+		const lambdaInvokeStep = new LambdaInvoke(
+			this,
+			'ReDriveFromS3StepFunctionLambdaCall',
+			{
+				lambdaFunction: reDriveFromS3Lambda,
+			},
+		);
+
+		new StateMachine(this, 'ReDriveFromS3StepFunction', {
+			stateMachineName: `${this.stack}-${this.stage}-${appName}-redrive-from-s3-step-function`,
+			definitionBody: DefinitionBody.fromChainable(
+				lambdaInvokeStep.next(
+					new Choice(this, 'ReDriveFromS3StepFunctionIsDoneChoice')
+						.when(Condition.isNotNull('$.Payload'), lambdaInvokeStep)
+						.otherwise(new Pass(this, 'ReDriveFromS3StepFunctionIsDone')),
+				),
+			),
 		});
 
 		/**

--- a/cdk/lib/telemetry-stack.ts
+++ b/cdk/lib/telemetry-stack.ts
@@ -313,6 +313,12 @@ export class TelemetryStack extends GuStack {
 
 		telemetryDataBucket.grantRead(reDriveFromS3Lambda);
 		kinesisStream.grantWrite(reDriveFromS3Lambda);
+		kinesisStream.grant(
+			reDriveFromS3Lambda,
+			'kinesis:UpdateShardCount',
+			'kinesis:DescribeStream',
+			'kinesis:ListShards',
+		);
 
 		const lambdaInvokeStep = new LambdaInvoke(
 			this,

--- a/projects/definitions/IUserTelemetryEvent.ts
+++ b/projects/definitions/IUserTelemetryEvent.ts
@@ -27,6 +27,7 @@ export interface IUserTelemetryEvent {
 
   /**
    * The event metadata – any additional context we'd like to provide.
+   * IMPORTANT: this is re-written to '_tags' on the way to ELK (as 'tags' is reserved field name in logstash v8 onwards)
    */
   tags?: {
     [key: string]: string | number | boolean;

--- a/projects/definitions/IUserTelemetryEventWithId.ts
+++ b/projects/definitions/IUserTelemetryEventWithId.ts
@@ -1,0 +1,8 @@
+import {IUserTelemetryEvent} from "./IUserTelemetryEvent";
+
+export interface IUserTelemetryEventWithId extends IUserTelemetryEvent {
+  /**
+   * The unique id of this event, such that it can be written (and overwritten) in ELK.
+   */
+  id: string;
+}

--- a/projects/event-lambdas/package.json
+++ b/projects/event-lambdas/package.json
@@ -23,7 +23,7 @@
     "typescript": "^3.5.3"
   },
   "scripts": {
-    "build": "ncc build src/event-api-lambda/index.ts -o dist/event-api-lambda -m && ncc build src/event-s3-lambda/index.ts -o dist/event-s3-lambda -m",
+    "build": "ncc build src/event-api-lambda/index.ts -o dist/event-api-lambda -m && ncc build src/event-s3-lambda/index.ts -o dist/event-s3-lambda -m && ncc build src/redrive-from-S3-lambda/index.ts -o dist/redrive-from-S3-lambda -m",
     "start": "ts-node-dev --ignore-watch node_modules src/event-api-lambda/index.ts",
     "test": "JEST_CIRCUS=1 jest --coverage",
     "test:watch": "JEST_CIRCUS=1 jest --watch",

--- a/projects/event-lambdas/src/__tests__/fixtures.ts
+++ b/projects/event-lambdas/src/__tests__/fixtures.ts
@@ -2,22 +2,37 @@ import { set, flow } from "lodash/fp";
 import { S3Event } from "aws-lambda";
 import { IUserTelemetryEvent } from "../../../definitions/IUserTelemetryEvent";
 
+const event1: IUserTelemetryEvent = {
+  app: "example-app",
+  stage: "PROD",
+  type: "USER_ACTION_1",
+  value: 1,
+  eventTime: "2020-09-03T07:51:27.669Z"
+};
+
+const event2: IUserTelemetryEvent = {
+  app: "example-app",
+  stage: "PROD",
+  type: "USER_ACTION_2",
+  value: 1,
+  eventTime: "2020-09-03T07:51:27.669Z"
+};
+
 export const events: IUserTelemetryEvent[] = [
-  {
-    app: "example-app",
-    stage: "PROD",
-    type: "USER_ACTION_1",
-    value: 1,
-    eventTime: "2020-09-03T07:51:27.669Z"
-  },
-  {
-    app: "example-app",
-    stage: "PROD",
-    type: "USER_ACTION_2",
-    value: 1,
-    eventTime: "2020-09-03T07:51:27.669Z"
-  },
+  event1,
+  event2,
 ];
+
+export const eventsAfterKinesisTransforms: Array<IUserTelemetryEvent & {'@timestamp': string}> = [
+  {
+    "@timestamp": "2020-09-03T07:51:27.669Z",
+    ...event1
+  },
+  {
+    "@timestamp": "2020-09-03T07:51:27.669Z",
+    ...event2
+  }
+]
 
 export const eventsAsNDJSON = `{\"app\":\"example-app\",\"stage\":\"PROD\",\"type\":\"USER_ACTION_1\",\"value\":1,\"eventTime\":\"2020-09-03T07:51:27.669Z\"}
 {\"app\":\"example-app\",\"stage\":\"PROD\",\"type\":\"USER_ACTION_2\",\"value\":1,\"eventTime\":\"2020-09-03T07:51:27.669Z\"}

--- a/projects/event-lambdas/src/__tests__/fixtures.ts
+++ b/projects/event-lambdas/src/__tests__/fixtures.ts
@@ -1,13 +1,14 @@
 import { set, flow } from "lodash/fp";
 import { S3Event } from "aws-lambda";
 import { IUserTelemetryEvent } from "../../../definitions/IUserTelemetryEvent";
+import {IUserTelemetryEventWithId} from "../../../definitions/IUserTelemetryEventWithId";
 
 const event1: IUserTelemetryEvent = {
   app: "example-app",
   stage: "PROD",
   type: "USER_ACTION_1",
   value: 1,
-  eventTime: "2020-09-03T07:51:27.669Z"
+  eventTime: "2020-09-03T07:51:27.669Z",
 };
 
 const event2: IUserTelemetryEvent = {
@@ -23,13 +24,15 @@ export const events: IUserTelemetryEvent[] = [
   event2,
 ];
 
-export const eventsAfterKinesisTransforms: Array<IUserTelemetryEvent & {'@timestamp': string}> = [
+export const eventsAfterKinesisTransforms: Array<IUserTelemetryEventWithId & {'@timestamp': string}> = [
   {
     "@timestamp": "2020-09-03T07:51:27.669Z",
+    id: "example-key-9624bab7e023e0f950aa2a5569dd6e8baa5140e9",
     ...event1
   },
   {
     "@timestamp": "2020-09-03T07:51:27.669Z",
+    id: "example-key-03bc2dc43854921a072c602fdb861fe5d59e2891",
     ...event2
   }
 ]

--- a/projects/event-lambdas/src/event-s3-lambda/__tests__/s3-event-lambda.spec.ts
+++ b/projects/event-lambdas/src/event-s3-lambda/__tests__/s3-event-lambda.spec.ts
@@ -2,7 +2,7 @@ import { handler } from "../index";
 import {
   getApiGatewayEventForPutEvent,
   eventsAsNDJSON,
-  events,
+  eventsAfterKinesisTransforms,
 } from "../../__tests__/fixtures";
 
 import { s3 } from "../../lib/aws";
@@ -83,6 +83,6 @@ describe("s3 event handler", () => {
       .slice(result.Records.length - 2)
       .map((record) => JSON.parse(record.Data.toString()));
 
-    expect(dataFromStream).toEqual(events);
+    expect(dataFromStream).toEqual(eventsAfterKinesisTransforms);
   });
 });

--- a/projects/event-lambdas/src/event-s3-lambda/index.ts
+++ b/projects/event-lambdas/src/event-s3-lambda/index.ts
@@ -1,7 +1,7 @@
 import { APIGatewayProxyResult, S3Event } from "aws-lambda";
 
 import { createOkResponse, createErrorResponse } from "../lib/response";
-import { getEventsFromS3File, putEventsToKinesisStream } from "../lib/util";
+import {augmentWithId, getEventsFromS3File, putEventsToKinesisStream} from "../lib/util";
 
 export const handler = async (
   event: S3Event
@@ -31,7 +31,7 @@ export const handler = async (
     };
   }
 
-  await putEventsToKinesisStream(maybeEvents.value);
+  await putEventsToKinesisStream(maybeEvents.value.map(augmentWithId(Key)));
 
   const message = `Written ${maybeEvents.value.length} events to Kinesis`;
   console.log(message);

--- a/projects/event-lambdas/src/lib/util.ts
+++ b/projects/event-lambdas/src/lib/util.ts
@@ -114,7 +114,7 @@ export const convertNDJSONToEvents = (json: string) => {
 };
 
 const fiveMegabyteInBytes = 5 * 1024 * 1024;
-export const putEventsToKinesisStream = async (events: IUserTelemetryEvent[]) => {
+export const putEventsToKinesisStream = async (events: IUserTelemetryEvent[], options?: { shouldThrowOnError?: boolean }) => {
   const chunkedRecords: PutRecordsRequestEntryList[] = events.reduce((acc, event) => {
     const record = {
       Data: JSON.stringify({
@@ -148,6 +148,9 @@ export const putEventsToKinesisStream = async (events: IUserTelemetryEvent[]) =>
     const recordsWithErrors = putRecordsResult.Records.filter(_ => !!_.ErrorCode);
     if(recordsWithErrors.length > 0) {
       console.error("Failed to write some records to Kinesis", recordsWithErrors)
+      if(options?.shouldThrowOnError){
+        throw new Error(`Failed to write ${recordsWithErrors.length} records to Kinesis. Terminating.`)
+      }
     }
 
     console.log(`Written ${Records.length} of ${events.length} events to Kinesis`);

--- a/projects/event-lambdas/src/lib/util.ts
+++ b/projects/event-lambdas/src/lib/util.ts
@@ -114,7 +114,10 @@ export const convertNDJSONToEvents = (json: string) => {
 
 export const putEventsToKinesisStream = (events: IUserTelemetryEvent[]) => {
   const Records = events.map((event) => ({
-    Data: JSON.stringify(event),
+    Data: JSON.stringify({
+      "@timestamp": event.eventTime,
+      ...event
+    }),
     // Ordering doesn't matter
     PartitionKey: uuidv4(),
   }));

--- a/projects/event-lambdas/src/redrive-from-S3-lambda/index.ts
+++ b/projects/event-lambdas/src/redrive-from-S3-lambda/index.ts
@@ -42,7 +42,7 @@ export const handler = async (
 
     console.log(`page of files: ${pageOfFiles.length}, starting at ${pageOfFilesResponse.Marker}`);
 
-    const eventsArrays = await Promise.all(pageOfFiles.map(async (file) => {
+    const eventsArrays = await Promise.all(pageOfFiles.map(async (file, index) => {
       const Key = file.Key;
 
       if(!Key) {
@@ -50,9 +50,7 @@ export const handler = async (
         return [];
       }
 
-      const position = pageOfFiles.indexOf(file) + 1;
-
-      console.log(`Attempting to read from file (${position} of ${pageOfFiles.length}) at s3://${telemetryBucketName}/${Key}`);
+      console.log(`Attempting to read from file (${index + 1} of ${pageOfFiles.length}) at s3://${telemetryBucketName}/${Key}`);
 
       const maybeEvents = await getEventsFromS3File(Key);
 

--- a/projects/event-lambdas/src/redrive-from-S3-lambda/index.ts
+++ b/projects/event-lambdas/src/redrive-from-S3-lambda/index.ts
@@ -27,7 +27,7 @@ export const handler = async (
     const pageOfFilesResponse = await s3.listObjects({
       Bucket: telemetryBucketName,
       Marker: maybeMarker,
-      MaxKeys: 1000, // max allowed
+      MaxKeys: 500, // max allowed
     }).promise();
 
     const pageOfFiles = pageOfFilesResponse.Contents;

--- a/projects/event-lambdas/src/redrive-from-S3-lambda/index.ts
+++ b/projects/event-lambdas/src/redrive-from-S3-lambda/index.ts
@@ -64,18 +64,12 @@ export const handler = async (
 
     const events = eventsArrays.flat();
 
-    await new Promise(resolve =>
-      setInterval(() => {
-
-      }, 1000) // once batch of records per second to avoid kinesis throttling
-    );
-
     for(let i = 0; i < Math.ceil(events.length / 50); i++) {
       const chunk = events.slice(i * 50, (i + 1) * 50);
       chunk.length > 0 && await putEventsToKinesisStream(chunk);
       console.log(`Written ${chunk.length} of ${events.length} events to Kinesis`);
       // one batch of records per second to avoid kinesis throttling
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await (new Promise(resolve => setTimeout(resolve, 1000)));
     }
 
     if(!pageOfFilesResponse.IsTruncated) {

--- a/projects/event-lambdas/src/redrive-from-S3-lambda/index.ts
+++ b/projects/event-lambdas/src/redrive-from-S3-lambda/index.ts
@@ -1,0 +1,91 @@
+import {getEventsFromS3File, putEventsToKinesisStream} from "../lib/util";
+import {s3} from "../lib/aws";
+import {telemetryBucketName} from "../lib/constants";
+import {Marker} from "aws-sdk/clients/s3";
+
+const tenMinsInMillis = 10 * 60 * 1000;
+
+type MarkerDone = null;
+
+export const handler = async (
+  event: { Payload?: Marker | unknown }
+): Promise<Marker | MarkerDone> => {
+
+  const startTimeEpoch = new Date().getTime();
+
+  if(typeof event?.Payload !== "undefined" && typeof event?.Payload !== "string") {
+    console.error("Invalid input.", event)
+    throw Error("Invalid input. Expected string, got " + typeof event.Payload);
+  }
+
+  const maybeStartingMarker = event?.Payload;
+
+  const processPageOfFiles = async (maybeMarker: Marker | undefined): Promise<Marker | MarkerDone> => {
+
+    // we could instead turn on bucket inventory, and work through that
+    // (this would mean we could start with latest, working back through time, as more recent is probably most useful/urgent)
+    const pageOfFilesResponse = await s3.listObjects({
+      Bucket: telemetryBucketName,
+      Marker: maybeMarker,
+      MaxKeys: 1000, // max allowed
+    }).promise();
+
+    const pageOfFiles = pageOfFilesResponse.Contents;
+
+    if(!pageOfFiles || pageOfFiles.length === 0) {
+      console.log("No files to process")
+      return null;
+    }
+
+
+    console.log(`page of files: ${pageOfFiles.length}, starting at ${pageOfFilesResponse.Marker}`);
+
+    const eventsArrays = await Promise.all(pageOfFiles.map(async (file) => {
+      const Key = file.Key;
+
+      if(!Key) {
+        console.error("No key found in file", file);
+        return [];
+      }
+
+      const position = pageOfFiles.indexOf(file) + 1;
+
+      console.log(`Attempting to read from file (${position} of ${pageOfFiles.length}) at s3://${telemetryBucketName}/${Key}`);
+
+      const maybeEvents = await getEventsFromS3File(Key);
+
+      if (maybeEvents.error) {
+        console.error(`Invalid data in file with key ${Key}`, maybeEvents.error);
+        return [];
+      }
+
+      return maybeEvents.value;
+    }));
+
+    const events = eventsArrays.flat();
+
+    for(let i = 0; i < Math.ceil(events.length / 50); i++) {
+      const chunk = events.slice(i * 50, (i + 1) * 50);
+      chunk.length > 0 && await putEventsToKinesisStream(chunk); // TODO handle error?
+      console.log(`Written ${chunk.length} of ${events.length} events to Kinesis`);
+    }
+
+    if(!pageOfFilesResponse.IsTruncated) {
+      console.log("No more files to process. Re-drive complete 🎉")
+      return null;
+    }
+
+    const nextMarker = pageOfFilesResponse.NextMarker || pageOfFiles[pageOfFiles.length - 1].Key!;
+
+    // so long as we have at least five mins before 15min timeout, do another page
+    if(new Date().getTime() - startTimeEpoch < tenMinsInMillis) {
+      return await processPageOfFiles(nextMarker);
+    }
+
+    return nextMarker; // too close to timing out, so finish the lambda and allow the step function to loop
+  };
+
+  return await processPageOfFiles(maybeStartingMarker || undefined); // coerce empty string etc to undefined, i.e. not starting marker;
+}
+
+

--- a/projects/event-lambdas/src/redrive-from-S3-lambda/index.ts
+++ b/projects/event-lambdas/src/redrive-from-S3-lambda/index.ts
@@ -64,7 +64,7 @@ export const handler = async (
 
     const events = eventsArrays.flat();
 
-    await putEventsToKinesisStream(events);
+    await putEventsToKinesisStream(events, {shouldThrowOnError: true});
 
     if(!pageOfFilesResponse.IsTruncated) {
       console.log("No more files to process. Re-drive complete 🎉")

--- a/projects/event-lambdas/src/redrive-from-S3-lambda/index.ts
+++ b/projects/event-lambdas/src/redrive-from-S3-lambda/index.ts
@@ -64,10 +64,18 @@ export const handler = async (
 
     const events = eventsArrays.flat();
 
+    await new Promise(resolve =>
+      setInterval(() => {
+
+      }, 1000) // once batch of records per second to avoid kinesis throttling
+    );
+
     for(let i = 0; i < Math.ceil(events.length / 50); i++) {
       const chunk = events.slice(i * 50, (i + 1) * 50);
-      chunk.length > 0 && await putEventsToKinesisStream(chunk); // TODO handle error?
+      chunk.length > 0 && await putEventsToKinesisStream(chunk);
       console.log(`Written ${chunk.length} of ${events.length} events to Kinesis`);
+      // one batch of records per second to avoid kinesis throttling
+      await new Promise(resolve => setTimeout(resolve, 1000));
     }
 
     if(!pageOfFilesResponse.IsTruncated) {

--- a/projects/event-lambdas/src/redrive-from-S3-lambda/index.ts
+++ b/projects/event-lambdas/src/redrive-from-S3-lambda/index.ts
@@ -1,7 +1,7 @@
 import {
   getEventsFromS3File,
   putEventsToKinesisStream,
-  commenceScaleKinesisShardCount,
+  commenceScaleKinesisShardCount, augmentWithId,
 } from "../lib/util";
 import {s3} from "../lib/aws";
 import {telemetryBucketName} from "../lib/constants";
@@ -75,7 +75,7 @@ export const handler = async (
         return [];
       }
 
-      return maybeEvents.value;
+      return maybeEvents.value.map(augmentWithId(Key));
     }));
 
     const events = eventsArrays.flat();

--- a/projects/event-lambdas/tsconfig.json
+++ b/projects/event-lambdas/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2017",
+    "lib": ["es2019"],
+    "target": "es2019",
     "module": "commonjs",
     "noEmit": true,
     "strict": true,


### PR DESCRIPTION
One of the key principles of our central ELK stack is that it can be rebuilt from elsewhere (if the cluster goes away for whatever reason) previously this was not possible for the telemetry index since it goes back a number of years (the conception of this telemetry service) but the kinesis stream understandably only retains data for a week or two.

So we need a way to be able to rebuild an index in ELK with ALL the data from the S3 bucket (37GB at the time of writing), however its worth noting (and what prompted this work) is that since logstash v8 the `tags` field (integral to our telemetry events) is now a reserved fields name and is automatically re-written to `_tags` (for the time being, from v9 it will be rejected entirely) so first off in the PR we start re-writing the `tags` field as `_tags` explicitly on the way out to ELK (via kinesis).

## What does this change?

### Pre-requistes

- add `@timestamp` event field (using value from `eventTime`) on the way out to Kinesis so that ELK places it in a historically correct position and puts it in the correct index (rather than all in one)
- check for `ErrorCode` on the response from kinesis PutRecords, since throttling won't fail the overall request but some records might individually fail (this should improve the integrity of the `event-s3-lambda` too - CC @jonathonherbert)
- re-write `tags` to `_tags` on the way out to ELK (via kinesis) since `tags` is reserved field name in logstash v8 onwards
- add an `id` field to events (built from the filename plus a SHA1 hash of the event) such that it can be used for ELK (after transformation into the `_id` field - **_TODO add PR once made_**) to deduplicate on indexing, such that we can re-drive at will, without skewing the telemetry data

### Main changes
This introduces a lambda which...

1. lists the event JSON files in the bucket (500 at a time)
2. re-uses existing logic to read out all the `IUserTelemetryEvent`
3. attempts to double the shard count (to increase throughput)
4. then sends these to the Kinesis stream (chunked into max 500 records per PutRecords or 5MB), then throttled to fit the  1MB limit pE) - with the transformations mentioned above
5. repeats steps 1-4, so long as there's at least five mins left before the 15min lambda timeout
6. returns the bucket key/marker ready for the next iteration of the lambda
7. unless we've processed all the files, in which case the lambda logs `No more files to process.` and returns `SCALING_DOWN_KINESIS`, the subsequent invocation(s) of the lambda then continually half the shard count until it gets back down to 1, at which point it returns `null`...

...this lambda is wrapped in a StepFunction in a loop, passing the bucket key/marker between invocations, waiting for `null` emitted from the lambda to denote completion (there's also a log message from the lambda `Kinesis has scaled back down to 1 shard. Re-drive complete 🎉`).

## Testing
The step function has been executed in CODE, where it replayed approx 2.5million events in around 18mins. With a throughput of around 20MB/min (once it scaled up the shards)... 
<img width="1405" alt="image" src="https://github.com/user-attachments/assets/9caa3fbd-6234-4bab-8bf8-a301b00873b6">
... averaging around 80k records per min, with no failed/throttled records...
<img width="1386" alt="image" src="https://github.com/user-attachments/assets/afd18eb2-2a7c-40af-a215-7bdccb1f5687">
...so, extrapolating that, **re-driving the PROD bucket's 100+ million events will take around 12hours.**

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
