### PR TITLE
upgrade pan-domain-node to 0.5.0 to get updated expiry logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "editorial-tools-user-telemetry-service",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}

--- a/projects/event-lambdas/package-lock.json
+++ b/projects/event-lambdas/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@guardian/pan-domain-node": "^0.4.2",
+        "@guardian/pan-domain-node": "^0.5.0",
         "@types/aws-lambda": "^8.10.31",
         "@types/jest": "^24.0.17",
         "@types/lodash": "^4.14.161",
@@ -642,11 +642,12 @@
       }
     },
     "node_modules/@guardian/pan-domain-node": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@guardian/pan-domain-node/-/pan-domain-node-0.4.2.tgz",
-      "integrity": "sha512-FWFa5JMjkflP0VeDY1Jr3hYnoN+T93CDWoDAlEm+xOc6cc+/lIiDP7iKAshFNRGPYwuoJyTdl7BA+Lrb3UtcAQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@guardian/pan-domain-node/-/pan-domain-node-0.5.0.tgz",
+      "integrity": "sha512-mrDxyjFhV21AV5DIK3IUsOGUwHI5pwXho8vaQoY9fiotmp08h+gl0luH8t8J3ldp4YW9k7RbLpAyKebyLcHEbw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "cookie": "^0.3.1",
+        "cookie": "^0.4.1",
         "iniparser": "^1.0.5"
       }
     },
@@ -3594,9 +3595,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -13149,11 +13150,11 @@
       }
     },
     "@guardian/pan-domain-node": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@guardian/pan-domain-node/-/pan-domain-node-0.4.2.tgz",
-      "integrity": "sha512-FWFa5JMjkflP0VeDY1Jr3hYnoN+T93CDWoDAlEm+xOc6cc+/lIiDP7iKAshFNRGPYwuoJyTdl7BA+Lrb3UtcAQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@guardian/pan-domain-node/-/pan-domain-node-0.5.0.tgz",
+      "integrity": "sha512-mrDxyjFhV21AV5DIK3IUsOGUwHI5pwXho8vaQoY9fiotmp08h+gl0luH8t8J3ldp4YW9k7RbLpAyKebyLcHEbw==",
       "requires": {
-        "cookie": "^0.3.1",
+        "cookie": "^0.4.1",
         "iniparser": "^1.0.5"
       }
     },
@@ -15456,9 +15457,9 @@
       }
     },
     "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw=="
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/projects/event-lambdas/package.json
+++ b/projects/event-lambdas/package.json
@@ -30,7 +30,7 @@
     "generate-schema": "typescript-json-schema ./src/types.ts IEventApiInput --out ./src/schema/eventApiInput.schema.json --required"
   },
   "dependencies": {
-    "@guardian/pan-domain-node": "^0.4.2",
+    "@guardian/pan-domain-node": "^0.5.0",
     "@types/aws-lambda": "^8.10.31",
     "@types/jest": "^24.0.17",
     "@types/lodash": "^4.14.161",

--- a/projects/event-lambdas/src/lib/authentication.ts
+++ b/projects/event-lambdas/src/lib/authentication.ts
@@ -44,10 +44,24 @@ export async function authenticated(
       return;
     }
 
-    return panda.verify(cookie).then(({status}) => {
+    return panda.verify(cookie).then(({ status, user }) => {
       switch (status) {
         case AuthenticationStatus.AUTHORISED:
           return handler();
+
+        case AuthenticationStatus.EXPIRED:
+          if (user?.expires) {
+            const expiry = new Date(user.expires);
+            const endOfGracePeriod = new Date();
+            endOfGracePeriod.setHours(endOfGracePeriod.getHours() + 24);
+            if (expiry < endOfGracePeriod) {
+              return handler();
+            } else {
+              applyErrorResponse(res, 419, "Credentials have expired");
+              return;
+            }
+          }
+          // otherwise, fall through to 403
         default:
           applyErrorResponse(res, 403, "Invalid credentials");
           return;


### PR DESCRIPTION
Upgrades to pan-domain-node to get corrected cookie expiry logic - see https://github.com/guardian/pan-domain-authentication/pull/167

Leaves in an extended grace period - the telemetry service only allows appending telemetry events, so there's no ability for expired cookies to delete or modify existing events, and I'd prefer we not miss telemetry events to the risk of receiving "fraudulent" events