### PR TITLE
Support general page view telemetry

### DIFF
--- a/projects/user-telemetry-client/package-lock.json
+++ b/projects/user-telemetry-client/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.20"
+        "lodash": "^4.17.20",
+        "uuid": "^11.0.5"
       },
       "devDependencies": {
         "@types/fetch-mock": "^7.3.5",
@@ -8958,6 +8959,19 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "node_modules/uuid": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-8.1.1.tgz",
@@ -15946,6 +15960,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "uuid": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA=="
     },
     "v8-to-istanbul": {
       "version": "8.1.1",

--- a/projects/user-telemetry-client/package.json
+++ b/projects/user-telemetry-client/package.json
@@ -29,6 +29,7 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "lodash": "^4.17.20"
+    "lodash": "^4.17.20",
+    "uuid": "^11.0.5"
   }
 }

--- a/projects/user-telemetry-client/src/PageViewTelemetryService.ts
+++ b/projects/user-telemetry-client/src/PageViewTelemetryService.ts
@@ -1,0 +1,62 @@
+import { v4 } from 'uuid';
+import { UserTelemetryEventSender } from '.';
+
+// Send generic page view data for a tool, using an existing UserTelemetryEventSender.
+//
+// Trigger 'sendPageViewTelemetry' for each page view in a tool to gather page view data.
+//
+// For non-standard apps (e.g. nested apps or browser extensions) - you may want to override certain values 
+// that won't be available (storage) or that can't be accurately deduced from the page (stage, path)
+
+const getStoredId = (storage: Storage, key: string): string => {
+    const existingId = storage.getItem(key);
+    if (existingId) {
+        return existingId;
+    } else {
+        const id = v4();
+        storage.setItem(key, id);
+        return id;
+    }
+};
+
+const getStage = (): string => {
+    const url = window.location.hostname;
+    if (url.includes("local.dev-gutools.co.uk")) { return "LOCAL"; }
+    if (url.includes("test.dev-gutools.co.uk")) { return "TEST"; }
+    if (url.includes("code.dev-gutools.co.uk")) { return "CODE"; }
+    if (url.includes(".gutools.co.uk")) { return "PROD"; }
+    return "";
+};
+
+export class PageViewTelemetryService {
+    public constructor(
+        private userTelemetryEventSender: UserTelemetryEventSender, 
+        private app: string,
+        private stageOverride?: string, // Set this if we know that the environment is DEV or PROD, but it can't be
+        // deduced from the current page hostname.
+        private browserStorageOverride?: Storage, // We may want to override for browser extensions
+        private sessionStorageOverride?: Storage  // We may want to override for browser extensions
+    ){};
+    private getBrowserId = () => getStoredId(this.browserStorageOverride || localStorage, `${this.app}BrowserUuid`);
+
+    private getSessionId = () => getStoredId(this.sessionStorageOverride || sessionStorage, `${this.app}SessionUuid`);
+
+    public sendViewTelemetry(
+        pathOverride?: string, // We may way to override this value in, for instance, a browser extension,
+        // where we can identify which tab of an extension the viewer is viewing, not the web page path.
+    ): void {
+        this.userTelemetryEventSender.addEvent({ 
+            app: this.app,
+            stage: this.stageOverride || getStage(),
+            eventTime: new Date().toISOString(),
+            type: "TELEMETRY_PAGE_VIEW",
+            value: 1,
+            tags: {
+                filterType: "inclusion", 
+                browserUuid: this.getBrowserId(), 
+                sessionUuid: this.getSessionId(),
+                path: pathOverride || window.location.pathname
+            }
+        });
+    }
+}

--- a/projects/user-telemetry-client/src/index.ts
+++ b/projects/user-telemetry-client/src/index.ts
@@ -1,2 +1,3 @@
 export { IUserTelemetryEvent } from "../../definitions/IUserTelemetryEvent"
 export { UserTelemetryEventSender } from "./TelemetryService"
+export { PageViewTelemetryService } from "./PageViewTelemetryService"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We don't have standardised page view analytics across all of our tools.

Looking at the [Grid's](https://github.com/guardian/grid/) telemetry as prior art, I realised that I'd already added something similar to general analytics - though I never visualised it on a dashboard. Kahuna ([Grid](https://github.com/guardian/grid/) frontend) [collects session and browser IDs](https://github.com/guardian/grid/blob/70604dbcbc24af31036cdc40f8f20bb389b4999b/kahuna/public/js/services/telemetry.ts#L42), as part of our client telemetry in the grid.

I decided to do some investigation in Grafana to see if this information could be used in the manner I intended - the results of which can be seen in the 'General Analytics' section our [Grid Kahuna Telemetry dashboard](https://github.com/guardian/grid/blob/70604dbcbc24af31036cdc40f8f20bb389b4999b/kahuna/public/js/services/telemetry.ts#L42).

![image](https://github.com/user-attachments/assets/af735465-ff06-4148-a5ef-4fbf4786a03f)

The Grid telemetry was created to fire for only two kinds of events - searches and filters. As such, we don't have 'page view' level datapoints, and users who load the grid without doing a search or changes filters won't show up in the telemetry. With other tools, we'll want to fire a page view event on page load.

Extending this telemetry concept from the Grid, this PR adds a new class to editorial-tools-user-telemetry-service, `PageViewTelemetryService`. This is designed to be imported in our tools, instantiated, and for us to call its `sendViewTelemetry` method on each page view.

Our tools are quite varied in their technical structure, though most of them at least have a client. Some are static webpages, some are built by webpack or rollup (via vite), some are Chrome extensions. This `class` aims to be usable in any tool that uses a package manager as part of its build process. Because 'storage', 'page path' and 'stage' are dependent on the context of the application, they can all be overridden in the class and its method. E.g. browser extensions normally provide their own [storage system](https://developer.chrome.com/docs/extensions/reference/api/storage), and might have their own 'tabs' or 'pages' that exist outside of the current browser's page path.

The fired events will show up with the following values:
- `type: "TELEMETRY_PAGE_VIEW"`
- `stage" ["CODE"|"PROD"|"TEST"|"LOCAL"|""] // Test is for the Grid`
- `tags.browserUuid: [random string]`
- `tags.sessionUuid: [random string]`
- `tags.path: [string of page path or manually provided identifier]`

## How to test

The best option for testing this library change is to build it locally and import in a local application via `yalc`, add the telemetry, and see that it ends up in the data used by Grafana. I haven't done this yet but will try and give it a go before I go on annual leave.