### PR TITLE
Adds Telemetry tracking pixel endpoint for monitoring tool usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ flowchart LR
         UTP(Tracking pixel)
     end
     UTC--"HTTP POST /event (cookie w/ pan-domain-auth)"-->AG[API Gateway]
-UTP--"HTTP GET /tracking-pixel?app=[app]&stage=[stage]&path=[path]"-->AG
+UTP--"HTTP GET /guardian-tool-accessed?app=[app]&stage=[stage]&path=[path]"-->AG
 SRV[Server]--"HTTP POST /event (headers w/ hmac auth)"-->AG
 subgraph "AWS (composer)"
 AG-->EAL[event-api-lambda]
@@ -52,20 +52,20 @@ await telemetryService.flushEvents();
 
 ### Tracking Pixel
 
-Alternatively, basic visits to a page can be identified using the `/tracking-pixel` endpoint. This can be requested
+Alternatively, basic visits to a page can be identified using the `/guardian-tool-accessed` endpoint. This can be requested
 either via a script or an HTML img element.
 
 Script:
 
 ```JavaScript
 const image = new Image();
-image.src = "https://[telemetry-backend-domain]/tracking-pixel?app=[app]&stage=[stage]&path=[path]";
+image.src = "https://[telemetry-backend-domain]/guardian-tool-accessed?app=[app]&stage=[stage]&path=[path]";
 ```
 
 Image Tag:
 
 ```HTML
-<img height=0 width=0 src="https://[telemetry-backend-domain]/tracking-pixel?app=[app]&stage=[stage]&path=[path]">
+<img height=0 width=0 src="https://[telemetry-backend-domain]/guardian-tool-accessed?app=[app]&stage=[stage]&path=[path]">
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ requests from clients, and [hmac](https://github.com/guardian/hmac-headers) to a
 flowchart LR
     subgraph "Client (Browser)"
         UTC[user-telemetry-client]
+        UTP(Tracking pixel)
     end
     UTC--"HTTP POST /event (cookie w/ pan-domain-auth)"-->AG[API Gateway]
+UTP--"HTTP GET /tracking-pixel?app=[app]&stage=[stage]&path=[path]"-->AG
 SRV[Server]--"HTTP POST /event (headers w/ hmac auth)"-->AG
 subgraph "AWS (composer)"
 AG-->EAL[event-api-lambda]

--- a/README.md
+++ b/README.md
@@ -1,26 +1,71 @@
 # editorial-tools-user-telemetry-service
 
-A service to receive telemetry events and pass them on to a kinesis stream. Designed to be used across the Guardian's internal tooling to help the Journalism stream gather data about tool usage. The package is published as [@guardian/user-telemetry-client](https://www.npmjs.com/package/@guardian/user-telemetry-client).
+A service to receive telemetry events and pass them on to a kinesis stream. Designed to be used across the Guardian's
+internal tooling to help the Journalism stream gather data about tool usage. The package is published
+as [@guardian/user-telemetry-client](https://www.npmjs.com/package/@guardian/user-telemetry-client).
 
-The service uses [pan-domain-authentication](https://github.com/guardian/pan-domain-authentication) to authenticate requests from clients, and [hmac](https://github.com/guardian/hmac-headers) to authenticate requests from servers.
+The service uses [pan-domain-authentication](https://github.com/guardian/pan-domain-authentication) to authenticate
+requests from clients, and [hmac](https://github.com/guardian/hmac-headers) to authenticate requests from servers.
 
 ```mermaid
 flowchart LR
     subgraph "Client (Browser)"
-    UTC[user-telemetry-client]
+        UTC[user-telemetry-client]
     end
     UTC--"HTTP POST /event (cookie w/ pan-domain-auth)"-->AG[API Gateway]
-    SRV[Server]--"HTTP POST /event (headers w/ hmac auth)"-->AG
-    subgraph "AWS (composer)"
-    AG-->EAL[event-api-lambda]
-    EAL--PutObject-->S3[(S3)]
-    S3--PutObject Event-->ESL[event-s3-lambda]
-    ESL-->K[[Kinesis]]
-    end
-    subgraph "AWS (deploy-tools)"
-    K-->CE[(Central ELK)]
-    end
+SRV[Server]--"HTTP POST /event (headers w/ hmac auth)"-->AG
+subgraph "AWS (composer)"
+AG-->EAL[event-api-lambda]
+EAL--PutObject-->S3[(S3)]
+S3--PutObject Event-->ESL[event-s3-lambda]
+ESL-->K[[Kinesis]]
+end
+subgraph "AWS (deploy-tools)"
+K-->CE[(Central ELK)]
+end
 ```
+
+## Sending tracking events
+
+### User Telemetry Client
+
+Events are intended to be sent via the [User Telemetry Client package](./projects/user-telemetry-client), using
+the [IUserTelemetryEvent](./projects/definitions/IUserTelemetryEvent.ts) interface.
+
+For example:
+
+```TypeScript
+const telemetryService = new UserTelemetryEventSender(url);
+
+telemetryService.addEvent(exampleEvent);
+```
+
+Events are accumulated and sent asynchronously, with a retry mechanism in case of issues.
+
+If events need to be sent synchronously, the `flushEvents` method can be used.
+
+```TypeScript
+await telemetryService.flushEvents();
+```
+
+### Tracking Pixel
+
+Alternatively, basic visits to a page can be identified using the `/tracking-pixel` endpoint. This can be requested
+either via a script or an HTML img element.
+
+Script:
+
+```JavaScript
+const image = new Image();
+image.src = "https://[telemetry-backend-domain]/tracking-pixel?app=[app]&stage=[stage]&path=[path]";
+```
+
+Image Tag:
+
+```HTML
+<img height=0 width=0 src="https://[telemetry-backend-domain]/tracking-pixel?app=[app]&stage=[stage]&path=[path]">
+```
+
 
 ## Creating the stack
 
@@ -32,12 +77,13 @@ To release changes, deploy the `editorial-tools-user-telemetry-service` project 
 
 ## Creating and deploying the package
 
-Deploying the package should be handled automatically when changes are made to the user-telemetry-client subproject. The merge commit for the PR should use the [conventional commits syntax](https://www.conventionalcommits.org/en/v1.0.0/).
+Deploying the package should be handled automatically when changes are made to the user-telemetry-client subproject. The
+merge commit for the PR should use the [conventional commits syntax](https://www.conventionalcommits.org/en/v1.0.0/).
 
 ## Rotating the HMAC key used by machine clients
 
 The API allows users to authenticate using a HMAC header compatible with
- [guardian/panda-hmac](https://github.com/guardian/panda-hmac). It uses a
+[guardian/panda-hmac](https://github.com/guardian/panda-hmac). It uses a
 secret key which is stored in AWS secrets manager, this is rotated regularly.
 
 A script is available in this repository to facilitate updating this key:
@@ -57,5 +103,7 @@ Are you sure you want to do this? [Yy]y
 Done!
 ```
 
-**You will have 5 days to update machine clients** that use this key, contact the [Editorial Systems Development (ESD)](https://github.com/orgs/guardian/teams/esd) team before doing this so that the can ensure they new key is
+**You will have 5 days to update machine clients** that use this key, contact
+the [Editorial Systems Development (ESD)](https://github.com/orgs/guardian/teams/esd) team before doing this so that the
+can ensure they new key is
 rolled out.

--- a/projects/event-lambdas/src/event-api-lambda/__tests__/api-lambda.spec.ts
+++ b/projects/event-lambdas/src/event-api-lambda/__tests__/api-lambda.spec.ts
@@ -327,11 +327,11 @@ describe("Event API lambda", () => {
     });
   });
 
-  describe("/tracking-pixel", () => {
+  describe("/guardian-tool-accessed", () => {
     it("should return a 403 without an auth cookie", () => {
       return chai
           .request(testApp)
-          .get("/tracking-pixel")
+          .get("/guardian-tool-accessed")
           .send()
           .then((res) => {
             expect(res.status).toBe(403);
@@ -341,7 +341,7 @@ describe("Event API lambda", () => {
     it("should return a 400 without all the necessary params", () => {
       return chai
           .request(testApp)
-          .get("/tracking-pixel")
+          .get("/guardian-tool-accessed")
           .set("Cookie", "some_value")
           .send()
           .then((res) => {
@@ -352,7 +352,7 @@ describe("Event API lambda", () => {
     it("should return a 200 for valid request", () => {
       return chai
           .request(testApp)
-          .get("/tracking-pixel?app=TOOL_A&stage=DEV&path=/content")
+          .get("/guardian-tool-accessed?app=TOOL_A&stage=DEV&path=/content")
           .set("Cookie", "some_value")
           .send()
           .then((res) => {

--- a/projects/event-lambdas/src/event-api-lambda/application.ts
+++ b/projects/event-lambdas/src/event-api-lambda/application.ts
@@ -68,7 +68,7 @@ export const createApp = (initConfig: AppConfig): express.Application => {
       )
   );
 
-  app.get("/tracking-pixel",
+  app.get("/guardian-tool-accessed",
     async (req: Request, res: Response) =>
       authenticatePandaUser(
         initConfig.panDomainAuthentication,
@@ -89,35 +89,35 @@ export const createApp = (initConfig: AppConfig): express.Application => {
                 "Incorrect event format"
             );
             return;
+          }
+
+          const viewEvent: IUserTelemetryEvent = {
+            app: "tools-audit",
+            stage: "INFRA",
+            type: "GUARDIAN_TOOL_ACCESSED",
+            value: true,
+            eventTime: new Date().toISOString(),
+            tags: {
+              email,
+              stage,
+              app,
+              path,
+              ...(referrer.hostname && {
+                  ["referrer-hostname"]: referrer.hostname
+              }),
+              ...(referrer.pathname && {
+                  ["referrer-pathname"]: referrer.pathname
+              })
             }
+          }
 
-            const viewEvent: IUserTelemetryEvent = {
-              app: "tools-audit",
-              stage: "INFRA",
-              type: "GUARDIAN_TOOL_ACCESSED",
-              value: true,
-              eventTime: new Date().toISOString(),
-              tags: {
-                email,
-                stage,
-                app,
-                path,
-                ...(referrer.hostname && {
-                    ["referrer-hostname"]: referrer.hostname
-                }),
-                ...(referrer.pathname && {
-                    ["referrer-pathname"]: referrer.pathname
-                })
-              }
-            }
+          const fileKey = await putEventsIntoS3Bucket([viewEvent]);
+          console.log(
+              `Added telemetry tool view event to S3 at key ${fileKey}`
+          );
 
-            const fileKey = await putEventsIntoS3Bucket([viewEvent]);
-            console.log(
-                `Added telemetry tool view event to S3 at key ${fileKey}`
-            );
-
-            res.header("Cache-Control", "no-store")
-            applyOkResponse(res, 204, fileKey.join(","));
+          res.header("Cache-Control", "no-store")
+          applyOkResponse(res, 204, fileKey.join(","));
         }
     )
   );

--- a/projects/event-lambdas/src/event-api-lambda/application.ts
+++ b/projects/event-lambdas/src/event-api-lambda/application.ts
@@ -91,33 +91,16 @@ export const createApp = (initConfig: AppConfig): express.Application => {
             return;
           }
 
-          const viewEvent: IUserTelemetryEvent = {
-            app: "tools-audit",
-            stage: "INFRA",
-            type: "GUARDIAN_TOOL_ACCESSED",
-            value: true,
-            eventTime: new Date().toISOString(),
-            tags: {
-              email,
-              stage,
-              app,
-              path,
-              ...(referrer.hostname && {
-                  ["referrer-hostname"]: referrer.hostname
-              }),
-              ...(referrer.pathname && {
-                  ["referrer-pathname"]: referrer.pathname
-              })
-            }
-          }
-
-          const fileKey = await putEventsIntoS3Bucket([viewEvent]);
-          console.log(
-              `Added telemetry tool view event to S3 at key ${fileKey}`
-          );
+          const logJson = JSON.stringify({
+              message: "Guardian tool accessed",
+              hostname: referrer.hostname,
+              pathname: path,
+              userEmail: email
+          });
+          console.log(logJson);
 
           res.header("Cache-Control", "no-store")
-          applyOkResponse(res, 204, fileKey.join(","));
+          applyOkResponse(res, 204, "");
         }
     )
   );

--- a/projects/event-lambdas/src/event-api-lambda/application.ts
+++ b/projects/event-lambdas/src/event-api-lambda/application.ts
@@ -7,6 +7,7 @@ import { applyErrorResponse, applyOkResponse } from "./util";
 import type { AppConfig } from "./index";
 import {User} from "@guardian/pan-domain-node";
 import {IUserTelemetryEvent} from "../../../definitions/IUserTelemetryEvent";
+import * as url from "url";
 
 export const createApp = (initConfig: AppConfig): express.Application => {
   const app = express();
@@ -75,8 +76,8 @@ export const createApp = (initConfig: AppConfig): express.Application => {
                 req,
                 res,
                 async ({ email }: User) => {
-
                     const {app, stage} = req.query;
+                    const {hostname, pathname} = url.parse(req.header("referrer") || "");
 
                     if(!email ||
                         !app || typeof app !== "string" ||
@@ -100,6 +101,8 @@ export const createApp = (initConfig: AppConfig): express.Application => {
                             email,
                             stage,
                             app,
+                            ...(hostname && {hostname}),
+                            ...(pathname && {pathname})
                         }
                     }
 
@@ -108,7 +111,7 @@ export const createApp = (initConfig: AppConfig): express.Application => {
                         `Added telemetry tool view event to S3 at key ${fileKey}`
                     );
 
-                    applyOkResponse(res, 201, fileKey.join(","));
+                    applyOkResponse(res, 204, fileKey.join(","));
                 }
             )
     );

--- a/projects/event-lambdas/src/lib/authentication.ts
+++ b/projects/event-lambdas/src/lib/authentication.ts
@@ -7,6 +7,12 @@ import { PandaHmacAuthentication } from './panda-hmac'
 import { applyErrorResponse } from "../event-api-lambda/util";
 
 
+function getPandaCookie(req: Request): string {
+  return Array.isArray(req.headers["cookie"])
+      ? req.headers["cookie"][0]
+      : req.headers["cookie"] || "";
+}
+
 export async function authenticated(
   panda: Pick<PanDomainAuthentication,'verify'>,
   hmac: Pick<PandaHmacAuthentication,'verify'>,
@@ -33,9 +39,7 @@ export async function authenticated(
     }
   } else {
     // No HMAC authentication headers so assume we need to do regular panda auth
-    const cookie = Array.isArray(req.headers["cookie"])
-        ? req.headers["cookie"][0]
-        : req.headers["cookie"] || "";
+    const cookie = getPandaCookie(req);
 
     if (!cookie) {
       const message =
@@ -62,10 +66,7 @@ export async function authenticatePandaUser(
     res: Response,
     handler: (user: User) => Promise<void>
 ): Promise<void> {
-    // No HMAC authentication headers so assume we need to do regular panda auth
-    const cookie = Array.isArray(req.headers["cookie"])
-        ? req.headers["cookie"][0]
-        : req.headers["cookie"] || "";
+    const cookie = getPandaCookie(req);
 
     if (!cookie) {
       const message =


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Similar to the objectives of: https://github.com/guardian/editorial-tools-user-telemetry-service/pull/49

This is a the initial work to facilitate a low-effort approach in tracking tools, embedded with a tracking pixel. This would then make a request to this backend allow for tracking across tools. 

The request uses a combination of the Panda auth cookie, as well as expected query params to create events indicating which page was visited.

Example event:

```JSON
{
  "app": "tools-audit",
  "stage": "INFRA",
  "type": "GUARDIAN_TOOL_ACCESSED",
  "value": true,
  "eventTime": "2025-03-17T09:27:29.583Z",
  "tags": {
    "email": "sam.hession@guardian.co.uk",
    "stage": "CODE",
    "app": "composer",
    "path": "/",
    "referrer-hostname": "composer.code.dev-gutools.co.uk",
    "referrer-pathname": "/"
  }
}

```

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This endpoint is designed to be hit by requests for resources on tool pages.

Via JavaScript:

```JS
const image = new Image();
image.src = "https://user-telemetry.local.dev-gutools.co.uk/tracking-pixel?app=composer&stage=CODE&path=/";
```

Via HTML element:

```html
<img height=0 width=0 src="https://user-telemetry.local.dev-gutools.co.uk/tracking-pixel?app=composer&stage=CODE&path=/">
```

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

We have the means to track user attributed visits various tools by adding a small script or HTML element to them. 

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
This risks of this approach primarily relate to the capturing and retention of user data. These should be addressed before this is used in earnest. 
