### PR TITLE
feat: Bundle distributed code as ESM

### DIFF
--- a/projects/user-telemetry-client/package.json
+++ b/projects/user-telemetry-client/package.json
@@ -1,7 +1,12 @@
 {
   "name": "@guardian/user-telemetry-client",
   "version": "1.0.1",
-  "main": "dist/user-telemetry-client/src/index.js",
+  "main": "./dist/cjs/user-telemetry-client/src/index.js",
+  "exports": {
+    "types": "./dist/declaration/user-telemetry-client/src/index.d.ts",
+    "require": "./dist/cjs/user-telemetry-client/src/index.js",
+    "import": "./dist/esm/user-telemetry-client/src/index.js"
+  },
   "types": "dist/declaration/user-telemetry-client/src/index.d.ts",
   "license": "MIT",
   "publishConfig": {
@@ -13,7 +18,7 @@
   },
   "scripts": {
     "test": "jest --env=jsdom",
-    "build": "tsc --project tsconfig-build.json",
+    "build": "tsc -b ./tsconfig.cjs.json ./tsconfig.esm.json ./tsconfig.types.json",
     "release": "semantic-release"
   },
   "devDependencies": {

--- a/projects/user-telemetry-client/tsconfig-build.json
+++ b/projects/user-telemetry-client/tsconfig-build.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": [
-    "tests/**"
-  ]
-}

--- a/projects/user-telemetry-client/tsconfig.cjs.json
+++ b/projects/user-telemetry-client/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "tests/**",
+    "./dist/**/*"
+  ],
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "./dist/cjs",
+    "declaration": false,
+  }
+}

--- a/projects/user-telemetry-client/tsconfig.esm.json
+++ b/projects/user-telemetry-client/tsconfig.esm.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "tests/**",
+    "./dist/**/*"
+  ],
+  "compilerOptions": {
+    "outDir": "./dist/esm",
+  }
+}

--- a/projects/user-telemetry-client/tsconfig.json
+++ b/projects/user-telemetry-client/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2019",
-    "module": "commonjs",
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
     "lib": ["ES2019","DOM"],
     "declaration": true,
     "declarationMap": true,

--- a/projects/user-telemetry-client/tsconfig.json
+++ b/projects/user-telemetry-client/tsconfig.json
@@ -4,14 +4,14 @@
     "module": "ES2020",
     "moduleResolution": "node",
     "lib": ["ES2019","DOM"],
-    "declaration": true,
-    "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
-    "declarationDir": "dist/declaration",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-  }
+  },
+  "exclude": [
+    "./dist/**/*"
+  ]
 }

--- a/projects/user-telemetry-client/tsconfig.types.json
+++ b/projects/user-telemetry-client/tsconfig.types.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./build/types",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "declarationDir": "dist/declaration",
+  }
+}


### PR DESCRIPTION
## What does this change?

Bundle distributed code as ESM. Spiked to solve a problem where using a node-specific module, `crypto`, was causing issues when running the code in browsers. See #50. 

## How to test

Publish and import locally with `yalc` or similar in a consuming project. The module should work as usual. [Conditional exports via `exports`](https://nodejs.org/api/packages.html#conditional-exports) should ensure that consumers can choose which build they'd like to use, and the `main` entrypoint provides CJS as a default for bundlers that don't work with `exports`, like webpack 4 [(issue)](https://github.com/webpack/webpack/issues/9509).

## How can we measure success?

Everything continues to work for users.