### PR TITLE
Increase PROD reserved concurrency to 25 and reduces CODE to 5

### DIFF
--- a/cdk/lib/__snapshots__/telemetry-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/telemetry-stack.test.ts.snap
@@ -425,7 +425,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "FunctionName": "event-api-lambda-CODE",
         "Handler": "index.handler",
         "MemorySize": 128,
-        "ReservedConcurrentExecutions": 15,
+        "ReservedConcurrentExecutions": 5,
         "Role": {
           "Fn::GetAtt": [
             "EventApiLambdaServiceRole3695319B",
@@ -455,7 +455,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
             "Value": "CODE",
           },
         ],
-        "Timeout": 5,
+        "Timeout": 10,
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -698,7 +698,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "FunctionName": "event-s3-lambda-CODE",
         "Handler": "index.handler",
         "MemorySize": 128,
-        "ReservedConcurrentExecutions": 15,
+        "ReservedConcurrentExecutions": 5,
         "Role": {
           "Fn::GetAtt": [
             "EventS3LambdaServiceRole34104ADE",
@@ -728,7 +728,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
             "Value": "CODE",
           },
         ],
-        "Timeout": 5,
+        "Timeout": 10,
       },
       "Type": "AWS::Lambda::Function",
     },

--- a/cdk/lib/telemetry-stack.ts
+++ b/cdk/lib/telemetry-stack.ts
@@ -126,7 +126,7 @@ export class TelemetryStack extends GuStack {
 		const commonLambdaParams: Omit<FunctionProps, 'code'> = {
 			runtime: Runtime.NODEJS_20_X,
 			memorySize: 128,
-			timeout: Duration.seconds(5),
+			timeout: Duration.seconds(10),
 			handler: 'index.handler',
 			environment: {
 				STAGE: this.stage,
@@ -137,7 +137,7 @@ export class TelemetryStack extends GuStack {
 				TELEMETRY_BUCKET_NAME: telemetryDataBucket.bucketName,
 				HMAC_SECRET_LOCATION: hmacSecret.secretName,
 			},
-			reservedConcurrentExecutions: 15,
+			reservedConcurrentExecutions: this.stage === 'PROD' ? 25 : 5,
 		};
 
 		/**


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR is intended to facilitate the expected increase in backend load, attributable to https://github.com/guardian/teleporter/pull/153. The implementation sends a telemetry event per call to the most common endpoint. In the graph below, we show the existing Telemetry Lambda invocations and the same but with invocations from the Teleporter Lambda:

<img width="1399" alt="image" src="https://github.com/user-attachments/assets/6a2345e3-11c4-488a-ba64-d9ad817a90ca" />

– [Graph URL][1]

[1]: https://743583969668-p6l7alva.eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricsV2?graph=~(sparkline~false~metrics~(~(~'AWS*2fLambda~'Invocations~'FunctionName~'teleporter-lambda-PROD~(region~'eu-west-1~id~'m1~visible~false))~(~'...~'event-api-lambda-PROD~(id~'m2))~(~(expression~'SUM*28METRICS*28*29*29~label~'Predicted*20Traffic~id~'e1~color~'*2317becf~period~21600))~(~'AWS*2fLambda~'Throttles~'FunctionName~'event-api-lambda-PROD~(id~'m3~yAxis~'right~stat~'Maximum~visible~false))~(~'.~'ConcurrentExecutions~'.~'.~(id~'m4~yAxis~'right~stat~'Maximum~visible~false))~(~'.~'Duration~'.~'.~(stat~'Maximum~id~'m5~visible~false)))~period~21600~region~'eu-west-1~title~'Invocations~start~'-PT168H~end~'P0D~view~'singleValue~stacked~false~stat~'Sum~setPeriodToTimeRange~true~trend~false~liveData~false~singleValueFullPrecision~false)&query=~'*7bAWS*2fLambda*2cFunctionName*7d*20event-api-lambda-PROD

The backend is already seeing regular throttles under it's current load and concurrency reservation:  

<img width="1415" alt="image" src="https://github.com/user-attachments/assets/874c0134-0f6c-4aeb-9ea9-4baa81972754" />

 – [Graph URL][2]

[2]: https://743583969668-p6l7alva.eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricsV2?graph=~(sparkline~false~metrics~(~(~'AWS*2fLambda~'Invocations~'FunctionName~'teleporter-lambda-PROD~(region~'eu-west-1~id~'m1~visible~false))~(~'...~'event-api-lambda-PROD~(id~'m2))~(~(expression~'SUM*28METRICS*28*29*29~label~'Predicted*20Traffic~id~'e1~color~'*2317becf~period~21600))~(~'AWS*2fLambda~'Throttles~'FunctionName~'event-api-lambda-PROD~(id~'m3~yAxis~'right~stat~'Maximum~visible~false))~(~'.~'ConcurrentExecutions~'.~'.~(id~'m4~yAxis~'right~stat~'Maximum~visible~false))~(~'.~'Duration~'.~'.~(stat~'Maximum~id~'m5~visible~false)))~period~21600~region~'eu-west-1~title~'Invocations~start~'-PT168H~end~'P0D~view~'singleValue~stacked~false~stat~'Sum~setPeriodToTimeRange~true~trend~false~liveData~false~singleValueFullPrecision~false)&query=~'*7bAWS*2fLambda*2cFunctionName*7d*20event-api-lambda-PROD

<img width="1038" alt="image" src="https://github.com/user-attachments/assets/b4f8d4c0-a397-4376-af55-f3e542799d4f" />

– [Cost Explorer][3]

[3]: https://743583969668-p6l7alva.us-east-1.console.aws.amazon.com/costmanagement/home#/cost-explorer?chartStyle=STACK&costAggregate=netUnblendedCost&endDate=2025-03-31&excludeForecasting=true&filter=%5B%7B%22dimension%22:%7B%22id%22:%22TagKey%22,%22displayValue%22:%22Tag%22%7D,%22operator%22:%22INCLUDES%22,%22values%22:%5B%7B%22value%22:%22telemetry-stack%22,%22displayValue%22:%22telemetry-stack%22%7D,%7B%22value%22:%22user-telemetry%22,%22displayValue%22:%22user-telemetry%22%7D%5D,%22growableValue%22:%7B%22displayValue%22:%22App%22,%22value%22:%22App%22%7D%7D%5D&futureRelativeRange=CUSTOM&granularity=Daily&groupBy=%5B%22Service%22%5D&historicalRelativeRange=CURRENT_MONTH&isDefault=true&reportName=New%20cost%20and%20usage%20report&showOnlyUncategorized=false&showOnlyUntagged=false&startDate=2025-03-01&usageAggregate=undefined&useNormalizedUnits=false

### Timeout increase

From the metrics it appears we are regularly hitting the max duration for invocations, I have increased the timeout value in order to reduce the number of timeouts:

<img width="524" alt="image" src="https://github.com/user-attachments/assets/7510e6a6-5cc7-4794-962f-a5239e41c9e5" />


### [Concurrency Limit Behaviour](https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html)

Reserved concurrency takes away from the overall unreserved concurrency of all Lambdas in an account, cap'd by default at 1000.  

> You can reserve up to the Unreserved account concurrency value minus 100. The remaining 100 units of concurrency are for functions that aren't using reserved concurrency. For example, if your account has a concurrency limit of 1,000, you cannot reserve all 1,000 units of concurrency to a single function.

We are currently reserving 60 units between CODE and PROD, both having Lambdas which use 15. Instead this PR changes CODE to use 5 (10 total) and PROD to use 25 (50 total), leaving the current total reservation amount in tact.

From my reading of the costs, given the total reservation amount will remain the same, the impact on costs should be minimal: https://aws.amazon.com/lambda/pricing/

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Difficult to test outside of production, so we will need to keep a close eye on the graphs above. Increasing the limits for PROD should present no issues. 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Fewer throttled invocations! 

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
Costs and impact on performance have been considered and should be acceptable. 


