### PR TITLE
Persists tracking pixel events to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ end
 
 ## Sending tracking events
 
+### Data privacy
+
+The storage, retention and usage of tracked user data is determined by the Guardian's privacy policies. These 
+document should be considered the source of truth for any data privacy questions. Especially relevant, given tracking is
+intended for internal tools, is the "Employee privacy policy" and the "Use of Cookies and Usage Insights" section. 
+These policies can be accessed by Guardian employees via Spike.
+
+**If there are any doubts about a particular use-case, always consult the Data Protection Officer (DPO).**
+
 ### User Telemetry Client
 
 Events are intended to be sent via the [User Telemetry Client package](./projects/user-telemetry-client), using
@@ -68,21 +77,22 @@ Image Tag:
 <img height=0 width=0 src="https://[telemetry-backend-domain]/guardian-tool-accessed?app=[app]&stage=[stage]&path=[path]">
 ```
 
+## Development
 
-## Creating the stack
+### Creating the stack
 
 In `/cdk`, run `npm i` to install dependencies, and `npm run synth` to generate cloudformation for the stack.
 
-## Deploying the stack
+### Deploying the stack
 
 To release changes, deploy the `editorial-tools-user-telemetry-service` project in Riffraff.
 
-## Creating and deploying the package
+### Creating and deploying the package
 
 Deploying the package should be handled automatically when changes are made to the user-telemetry-client subproject. The
 merge commit for the PR should use the [conventional commits syntax](https://www.conventionalcommits.org/en/v1.0.0/).
 
-## Rotating the HMAC key used by machine clients
+### Rotating the HMAC key used by machine clients
 
 The API allows users to authenticate using a HMAC header compatible with
 [guardian/panda-hmac](https://github.com/guardian/panda-hmac). It uses a

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ end
 ### Data privacy
 
 The storage, retention and usage of tracked user data is determined by the Guardian's privacy policies. These 
-document should be considered the source of truth for any data privacy questions. Especially relevant, given tracking is
+documents should be considered the source of truth for any data privacy questions. Especially relevant, given tracking is
 intended for internal tools, is the "Employee privacy policy" and the "Use of Cookies and Usage Insights" section. 
 These policies can be accessed by Guardian employees via Spike.
 

--- a/projects/event-lambdas/src/event-api-lambda/application.ts
+++ b/projects/event-lambdas/src/event-api-lambda/application.ts
@@ -8,6 +8,7 @@ import type { AppConfig } from "./index";
 import {User} from "@guardian/pan-domain-node";
 import {IUserTelemetryEvent} from "../../../definitions/IUserTelemetryEvent";
 import * as url from "url";
+import {app as lambdaApp, stage as lambdaStage} from "../lib/constants"
 
 export const createApp = (initConfig: AppConfig): express.Application => {
   const app = express();
@@ -100,8 +101,8 @@ export const createApp = (initConfig: AppConfig): express.Application => {
           console.log(logJson);
 
           const viewEvent: IUserTelemetryEvent = {
-            app: "tools-audit",
-            stage: "INFRA",
+            app: lambdaApp,
+            stage: lambdaStage,
             type: "GUARDIAN_TOOL_ACCESSED",
             value: true,
             eventTime: new Date().toISOString(),

--- a/projects/event-lambdas/src/event-api-lambda/application.ts
+++ b/projects/event-lambdas/src/event-api-lambda/application.ts
@@ -99,8 +99,33 @@ export const createApp = (initConfig: AppConfig): express.Application => {
           });
           console.log(logJson);
 
+          const viewEvent: IUserTelemetryEvent = {
+            app: "tools-audit",
+            stage: "INFRA",
+            type: "GUARDIAN_TOOL_ACCESSED",
+            value: true,
+            eventTime: new Date().toISOString(),
+            tags: {
+              email,
+              stage,
+              app,
+              path,
+              ...(referrer.hostname && {
+                  ["referrer-hostname"]: referrer.hostname
+              }),
+              ...(referrer.pathname && {
+                  ["referrer-pathname"]: referrer.pathname
+              })
+            }
+          }
+
+          const fileKey = await putEventsIntoS3Bucket([viewEvent]);
+          console.log(
+              `Added telemetry tool view event to S3 at key ${fileKey}`
+          );
+
           res.header("Cache-Control", "no-store")
-          applyOkResponse(res, 204, "");
+          applyOkResponse(res, 204, fileKey.join(","));
         }
     )
   );

--- a/projects/event-lambdas/src/lib/constants.ts
+++ b/projects/event-lambdas/src/lib/constants.ts
@@ -8,3 +8,7 @@ export const hmacSecretLocation =
   process.env.HMAC_SECRET_LOCATION ||
   "/DEV/flexible/user-telemetry-service/hmacSecret";
 export const hmacAllowedDateOffsetInMillis = 300000;
+export const app =
+    process.env.APP || "user-telemetry";
+export const stage =
+    process.env.STAGE || "DEV";


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Building on from #52 this PR saves tracking events to S3. This was originally removed from #52 due to pending questions about our obligations for storing user data, which have since been discussed and resolved. We have discussed these changes with the DPO and are updating the relevant Guardian privacy policies to reflect the outcomes. 

The tracked data is intended for the improvement of internal tooling and falls under the Employee privacy policy. Data should be retained for [no more than 7 years](https://github.com/guardian/editorial-tools-user-telemetry-service/issues/55), users should be able access their own data if requested. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Testable locally or in CODE. Events should either by persisted to local stack or in the case of CODE, S3. 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Access events are stored in S3 for long-term analysis. All data privacy considerations have been addressed. 

