### PR TITLE
Changes the tracking pixel value to a number due to ES ingestion issue

### DIFF
--- a/projects/event-lambdas/src/event-api-lambda/application.ts
+++ b/projects/event-lambdas/src/event-api-lambda/application.ts
@@ -104,7 +104,7 @@ export const createApp = (initConfig: AppConfig): express.Application => {
             app: lambdaApp,
             stage: lambdaStage,
             type: "GUARDIAN_TOOL_ACCESSED",
-            value: true,
+            value: 1,
             eventTime: new Date().toISOString(),
             tags: {
               email,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR resolves an issue which was causing tracking pixel events to not be ingested into ElasticSearch. This was due to the mapping of the telemetry index expecting a Long and not a Boolean. 

<img width="268" alt="image" src="https://github.com/user-attachments/assets/03449939-600a-40c8-99c7-f8c2c762ccfa" />

The types of the telemetry events specify:

https://github.com/guardian/editorial-tools-user-telemetry-service/blob/9f101f23165ac78b482cdbd7627b4fab8f771e4b/projects/definitions/IUserTelemetryEvent.ts#L20

However they are converted to a number before being sent to the backend: 

https://github.com/guardian/editorial-tools-user-telemetry-service/blob/9f101f23165ac78b482cdbd7627b4fab8f771e4b/projects/user-telemetry-client/src/TelemetryService.ts#L46

This PR fixes the issue for events generated via the tracking pixel. We may also want to change these types for the telemetry client. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
Deployed to PROD and working, events visible here: https://logs.gutools.co.uk/s/editorial-tools/app/r/s/GMKBA

I manually deleted the S3 stored events generated prior to this change. 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Events are ingested into ElasticSearch as intended. 
