### PR TITLE
Determines a tools-accessed event stage via the referrer header

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Image Tag:
 <img height=0 width=0 src="https://[telemetry-backend-domain]/guardian-tool-accessed?app=[app]&stage=[stage]&path=[path]">
 ```
 
+> [!NOTE]
+> If no stage value is provided, the stage will be determined from the referrer header based on Guardian domain conventions.
+
 ## Development
 
 ### Creating the stack

--- a/projects/event-lambdas/src/event-api-lambda/__tests__/api-lambda.spec.ts
+++ b/projects/event-lambdas/src/event-api-lambda/__tests__/api-lambda.spec.ts
@@ -359,5 +359,28 @@ describe("Event API lambda", () => {
             expect(res.status).toBe(204);
           });
     });
+    
+    it("should determine stage from hostname when not provided", () => {
+      return chai
+          .request(testApp)
+          .get("/guardian-tool-accessed?app=TOOL_A&path=/content")
+          .set("Cookie", "some_value")
+          .set("Referer", "https://example.code.dev-gutools.co.uk/path")
+          .send()
+          .then((res) => {
+            expect(res.status).toBe(204);
+          });
+    });
+    
+    it("should reject the request if stage can't be determined from either params or referer", () => {
+      return chai
+          .request(testApp)
+          .get("/guardian-tool-accessed?app=TOOL_A&path=/content")
+          .set("Cookie", "some_value")
+          .send()
+          .then((res) => {
+            expect(res.status).toBe(400);
+          });
+    });
   });
 });

--- a/projects/event-lambdas/src/event-api-lambda/application.ts
+++ b/projects/event-lambdas/src/event-api-lambda/application.ts
@@ -101,7 +101,8 @@ export const createApp = (initConfig: AppConfig): express.Application => {
               message: "Guardian tool accessed",
               hostname: referrer.hostname,
               pathname: path,
-              userEmail: email
+              userEmail: email,
+              referrerStage: stage
           });
           console.log(logJson);
 

--- a/projects/event-lambdas/src/event-api-lambda/application.ts
+++ b/projects/event-lambdas/src/event-api-lambda/application.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import { Request, Response } from "express";
 
-import { putEventsIntoS3Bucket, parseEventJson } from "../lib/util";
+import { putEventsIntoS3Bucket, parseEventJson, determineStageFromHostname } from "../lib/util";
 import {authenticated, authenticatePandaUser} from "../lib/authentication";
 import { applyErrorResponse, applyOkResponse } from "./util";
 import type { AppConfig } from "./index";
@@ -76,8 +76,13 @@ export const createApp = (initConfig: AppConfig): express.Application => {
         req,
         res,
         async ({email}: User) => {
-          const {app, stage, path} = req.query;
+          const {app, path} = req.query;
+          let {stage} = req.query;
           const referrer = url.parse(req.header("referrer") || "");
+          
+          if ((!stage || typeof stage !== "string") && referrer.hostname) {
+            stage = determineStageFromHostname(referrer.hostname);
+          }
 
           if (!email ||
               !app || typeof app !== "string" ||

--- a/projects/event-lambdas/src/lib/__tests__/utils.spec.ts
+++ b/projects/event-lambdas/src/lib/__tests__/utils.spec.ts
@@ -16,11 +16,11 @@ jest.mock("uuid", () => ({
 
 describe("utils", () => {
   describe("determineStageFromHostname", () => {
-    it("returns null for empty hostname", () => {
-      expect(determineStageFromHostname("")).toBeNull();
+    it("returns undefined for empty hostname", () => {
+      expect(determineStageFromHostname("")).toBeUndefined();
     });
 
-    it("returns null for non-Guardian hostnames", () => {
+    it("returns undefined for non-Guardian hostnames", () => {
       expect(determineStageFromHostname("example.com")).toBeUndefined();
       expect(determineStageFromHostname("invalid-domain.co.uk")).toBeUndefined();
       expect(determineStageFromHostname("something.gutools.com")).toBeUndefined();

--- a/projects/event-lambdas/src/lib/__tests__/utils.spec.ts
+++ b/projects/event-lambdas/src/lib/__tests__/utils.spec.ts
@@ -3,6 +3,7 @@ import {
   convertEventsToNDJSON,
   convertNDJSONToEvents,
   putEventsIntoS3Bucket,
+  determineStageFromHostname,
 } from "../util";
 import { events, eventsAsNDJSON } from "../../__tests__/fixtures";
 import MockDate from "mockdate";
@@ -14,6 +15,36 @@ jest.mock("uuid", () => ({
 }));
 
 describe("utils", () => {
+  describe("determineStageFromHostname", () => {
+    it("returns null for empty hostname", () => {
+      expect(determineStageFromHostname("")).toBeNull();
+    });
+
+    it("returns null for non-Guardian hostnames", () => {
+      expect(determineStageFromHostname("example.com")).toBeUndefined();
+      expect(determineStageFromHostname("invalid-domain.co.uk")).toBeUndefined();
+      expect(determineStageFromHostname("something.gutools.com")).toBeUndefined();
+    });
+
+    it("returns PROD for .gutools.co.uk domains", () => {
+      expect(determineStageFromHostname("workflow.gutools.co.uk")).toBe("PROD");
+      expect(determineStageFromHostname("media-service.gutools.co.uk")).toBe("PROD");
+      expect(determineStageFromHostname("user-telemetry.gutools.co.uk")).toBe("PROD");
+    });
+
+    it("returns CODE for .code.dev-gutools.co.uk domains", () => {
+      expect(determineStageFromHostname("workflow.code.dev-gutools.co.uk")).toBe("CODE");
+      expect(determineStageFromHostname("grid.code.dev-gutools.co.uk")).toBe("CODE");
+      expect(determineStageFromHostname("user-telemetry.code.dev-gutools.co.uk")).toBe("CODE");
+    });
+
+    it("returns LOCAL for .local.dev-gutools.co.uk domains", () => {
+      expect(determineStageFromHostname("workflow.local.dev-gutools.co.uk")).toBe("LOCAL");
+      expect(determineStageFromHostname("composer.local.dev-gutools.co.uk")).toBe("LOCAL");
+      expect(determineStageFromHostname("user-telemetry.local.dev-gutools.co.uk")).toBe("LOCAL");
+    });
+  });
+
   describe("NDJSON conversion", () => {
     describe("convertEventsToNDJSON", () => {
       it("should convert an array of event data to a single NDJSON string", () => {

--- a/projects/event-lambdas/src/lib/util.ts
+++ b/projects/event-lambdas/src/lib/util.ts
@@ -14,6 +14,24 @@ import {IUserTelemetryEventWithId} from "../../../definitions/IUserTelemetryEven
 const ajv = new Ajv();
 const validateEventApiInput = ajv.compile(eventApiInputSchema);
 
+/**
+ * Determines the stage (environment) from a hostname
+ * @param hostname The hostname to extract stage from
+ * @returns The extracted stage (uppercase) or null if stage cannot be determined
+ */
+export const determineStageFromHostname = (hostname: string): string | undefined => {
+  if (!hostname) {
+    return undefined;
+  }
+  
+  const stageMatch = /^.*\.(?<environment>local|code)\.dev-gutools\.co\.uk$|^.*\.gutools\.co\.uk$/.exec(hostname);
+  if (stageMatch) {
+    return (stageMatch.groups?.environment || "PROD").toUpperCase();
+  }
+  
+  return undefined;
+};
+
 export const parseEventJson = (
   maybeEventJson: unknown
 ): Either<IUserTelemetryEvent[], Ajv.ErrorObject[]> => {

--- a/projects/event-lambdas/src/lib/util.ts
+++ b/projects/event-lambdas/src/lib/util.ts
@@ -17,7 +17,7 @@ const validateEventApiInput = ajv.compile(eventApiInputSchema);
 /**
  * Determines the stage (environment) from a hostname
  * @param hostname The hostname to extract stage from
- * @returns The extracted stage (uppercase) or null if stage cannot be determined
+ * @returns The extracted stage (uppercase) or undefined if stage cannot be determined
  */
 export const determineStageFromHostname = (hostname: string): string | undefined => {
   if (!hostname) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
This PR intends to making the tracking pixel in apps simpler by providing the means to determine an apps stage using the provided referrer header. This means we can reduce the amount of logic on the client to determine the stage of an environment. However, this can still be provided via the stage param. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
The unit tests should provide confidence this is going to work. We can also test in CODE or locally on a local gutool using the provided instructions in the top [README](https://github.com/guardian/editorial-tools-user-telemetry-service?tab=readme-ov-file#tracking-pixel). You should the correct stage in the log output or on logs.gutools.co.uk.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Client side tracking pixel code can remain slim. 

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
I feel this make the event-lambda backend more Guardian specific, which is not necessarily a problem but it would be nice to keep this repo generic if possible. 
