### PR TITLE
Init app outside API lambda handler

### DIFF
--- a/projects/event-lambdas/src/event-api-lambda/index.ts
+++ b/projects/event-lambdas/src/event-api-lambda/index.ts
@@ -51,14 +51,19 @@ async function initialise(): Promise<AppConfig> {
 }
 
 const appConfig = initialise();
+const server =
+    appConfig.then((config) => awsServerlessExpress.createServer(createApp(config)))
+        .catch((error) => {
+              console.error("Failed to initialise server", error);
+              throw error;
+            }
+        );
 
 export const handler: Handler = async (event, context) => {
   console.log("Lambda handler called, processing request.");
 
-  const app = createApp(await appConfig);
-
   return await awsServerlessExpress.proxy(
-    awsServerlessExpress.createServer(app),
+    await server,
     event,
     context,
     "PROMISE"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
We have been noticing a modest number of [errors outputted from the Telemetry API lambda](https://github.com/guardian/editorial-tools-user-telemetry-service/issues/60). This change is a sensible improvement, although I suspect unlikely to resolve the issue given the most likely offender, the AWS clients, are initialised outside of the handler: https://github.com/guardian/editorial-tools-user-telemetry-service/blob/90b353e0515bce09b473b6b26bb500ec827b6669/projects/event-lambdas/src/lib/aws.ts#L29-L31 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
This has been [deployed to CODE](https://riffraff.gutools.co.uk/deployment/view/4b8da1ea-602c-4a4e-a59d-ec108ad021a0) successfully, and is testable on apps using the tracking pixel such as https://tagmanager.code.dev-gutools.co.uk/. 

I recommend we also do a limited deploy to PROD and observe the results, given the issue is exclusively in PROD. 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
Observing the Lambda metrics, do we see fewer timeouts or reduced latency? 