### PR TITLE
Bump GuCDK to version 62.1.2

### DIFF
--- a/cdk/lib/__snapshots__/telemetry-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/telemetry-stack.test.ts.snap
@@ -129,7 +129,8 @@ def handle_managed(request_type, notification_configuration):
 def handle_unmanaged(bucket, stack_id, request_type, notification_configuration, old):
   def get_id(n):
     n['Id'] = ''
-    strToHash=json.dumps(n, sort_keys=True).replace('"Name": "prefix"', '"Name": "Prefix"').replace('"Name": "suffix"', '"Name": "Suffix"')
+    sorted_notifications = sort_filter_rules(n)
+    strToHash=json.dumps(sorted_notifications, sort_keys=True).replace('"Name": "prefix"', '"Name": "Prefix"').replace('"Name": "suffix"', '"Name": "Suffix"')
     return f"{stack_id}-{hash(strToHash)}"
   def with_id(n):
     n['Id'] = get_id(n)
@@ -183,7 +184,21 @@ def submit_response(event: dict, context, response_status: str, error_message: s
       print(response.read().decode("utf-8"))
     print("Status code: " + response.reason)
   except Exception as e:
-      print("send(..) failed executing request.urlopen(..): " + str(e))",
+      print("send(..) failed executing request.urlopen(..): " + str(e))
+
+def sort_filter_rules(json_obj):
+  if not isinstance(json_obj, dict):
+      return json_obj
+  for key, value in json_obj.items():
+      if isinstance(value, dict):
+          json_obj[key] = sort_filter_rules(value)
+      elif isinstance(value, list):
+          json_obj[key] = [sort_filter_rules(item) for item in value]
+  if "Filter" in json_obj and "Key" in json_obj["Filter"] and "FilterRules" in json_obj["Filter"]["Key"]:
+      filter_rules = json_obj["Filter"]["Key"]["FilterRules"]
+      sorted_filter_rules = sorted(filter_rules, key=lambda x: x["Name"])
+      json_obj["Filter"]["Key"]["FilterRules"] = sorted_filter_rules
+  return json_obj",
         },
         "Description": "AWS CloudFormation handler for "Custom::S3BucketNotifications" resources (@aws-cdk/aws-s3)",
         "Handler": "index.handler",
@@ -193,7 +208,7 @@ def submit_response(event: dict, context, response_status: str, error_message: s
             "Arn",
           ],
         },
-        "Runtime": "python3.11",
+        "Runtime": "python3.13",
         "Tags": [
           {
             "Key": "gu:cdk:version",
@@ -272,12 +287,40 @@ def submit_response(event: dict, context, response_status: str, error_message: s
             {
               "Action": "s3:PutBucketNotification",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::",
+                    {
+                      "Ref": "BucketName",
+                    },
+                  ],
+                ],
+              },
             },
             {
               "Action": "s3:GetBucketNotification",
               "Effect": "Allow",
-              "Resource": "*",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:",
+                    {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":s3:::",
+                    {
+                      "Ref": "BucketName",
+                    },
+                  ],
+                ],
+              },
             },
           ],
           "Version": "2012-10-17",
@@ -1745,6 +1788,9 @@ def submit_response(event: dict, context, response_status: str, error_message: s
         "usertelemetryproxyEC8A2D95",
         "usertelemetryANY08DB1886",
       ],
+      "Metadata": {
+        "aws:cdk:do-not-refactor": true,
+      },
       "Properties": {
         "Description": "Automatically created by the RestApi construct",
         "RestApiId": {

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8,14 +8,14 @@
       "name": "cdk",
       "version": "0.0.0",
       "devDependencies": {
-        "@guardian/cdk": "59.5.3",
+        "@guardian/cdk": "62.1.2",
         "@guardian/eslint-config-typescript": "8.0.0",
         "@guardian/prettier": "3.0.0",
         "@types/jest": "^29.5.13",
         "@types/node": "22.7.5",
-        "aws-cdk": "2.157.0",
-        "aws-cdk-lib": "2.157.0",
-        "constructs": "10.3.0",
+        "aws-cdk": "2.1031.1",
+        "aws-cdk-lib": "2.222.0",
+        "constructs": "10.4.2",
         "eslint": "^8.57.1",
         "jest": "^29.7.0",
         "prettier": "^2.4.0",
@@ -39,38 +39,35 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.207",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.207.tgz",
-      "integrity": "sha512-5oRh5Ad7hGSqwM3+/X8MmIkUjBMGU9sd1g+pa3L0s8IL15OQcFW0ZT0gsUdEb/N/JV663jUUpSbtD7pLO65O4Q==",
-      "dev": true
-    },
-    "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.3.tgz",
-      "integrity": "sha512-cDG1w3ieM6eOT9mTefRuTypk95+oyD7P5X/wRltwmYxU7nZc3+076YEVS6vrjDKr3ADYbfn0lDKpfB1FBtO9CQ==",
-      "dev": true
+      "version": "2.2.242",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.242.tgz",
+      "integrity": "sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
       "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "36.3.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-36.3.0.tgz",
-      "integrity": "sha512-mLSYgcMFTNCXrGAD7xob95p9s47/7WwEWUJiexxM46H2GxiijhlhLQJs31AS5uRRP6Cx1DLEu4qayKAUOOVGrw==",
+      "version": "48.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-48.19.0.tgz",
+      "integrity": "sha512-jefeDhIphmb/ahwqJ+kSbfUky3EPObDg34YIqmf6LfYMeI1/17I7eh5RopD7JfMyOizkE/H4K28sKGTSYrfiWg==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "jsonschema": "^1.4.1",
-        "semver": "^7.6.3"
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.2"
       },
       "engines": {
-        "node": ">= 18.18.0"
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
@@ -83,7 +80,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.6.3",
+      "version": "7.7.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -92,6 +89,861 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.934.0.tgz",
+      "integrity": "sha512-kEuo8vPwZ4f1RmUlMs86yNkz35SAQlVtso+z6KBjJKGH+p6KkZ6dWvYno18fb0IdVbo4KGeCCXfnV5LoNLkLxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/credential-provider-node": "3.934.0",
+        "@aws-sdk/middleware-host-header": "3.930.0",
+        "@aws-sdk/middleware-logger": "3.930.0",
+        "@aws-sdk/middleware-recursion-detection": "3.933.0",
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/region-config-resolver": "3.930.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@aws-sdk/util-user-agent-browser": "3.930.0",
+        "@aws-sdk/util-user-agent-node": "3.934.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.2",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/middleware-retry": "^4.4.9",
+        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.8",
+        "@smithy/util-defaults-mode-node": "^4.2.11",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ec2": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.934.0.tgz",
+      "integrity": "sha512-VMTBq5zYkgDAz2a+EI0E/ALZgNamS3223jwFXksfHAujc91xhqzmiknl1Tpu60W2KgJGxRrX5f5mcSBZEHismw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/credential-provider-node": "3.934.0",
+        "@aws-sdk/middleware-host-header": "3.930.0",
+        "@aws-sdk/middleware-logger": "3.930.0",
+        "@aws-sdk/middleware-recursion-detection": "3.933.0",
+        "@aws-sdk/middleware-sdk-ec2": "3.930.0",
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/region-config-resolver": "3.930.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@aws-sdk/util-user-agent-browser": "3.930.0",
+        "@aws-sdk/util-user-agent-node": "3.934.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.2",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/middleware-retry": "^4.4.9",
+        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.8",
+        "@smithy/util-defaults-mode-node": "^4.2.11",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-ssm": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.934.0.tgz",
+      "integrity": "sha512-sZdZIvXTaaB7FqVUU7354xHhN3FFTm70b9IQ9rfWZvQ7kGdHRaCitRZR7f6NE51hhwdXWwwky3MsN6rEN8RJAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/credential-provider-node": "3.934.0",
+        "@aws-sdk/middleware-host-header": "3.930.0",
+        "@aws-sdk/middleware-logger": "3.930.0",
+        "@aws-sdk/middleware-recursion-detection": "3.933.0",
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/region-config-resolver": "3.930.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@aws-sdk/util-user-agent-browser": "3.930.0",
+        "@aws-sdk/util-user-agent-node": "3.934.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.2",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/middleware-retry": "^4.4.9",
+        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.8",
+        "@smithy/util-defaults-mode-node": "^4.2.11",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.934.0.tgz",
+      "integrity": "sha512-gsgJevqhY0j3x014ejhXtHLCA6o83FYm3rJoZG7tqoy3DnWerLv/FHaAnHI/+Q+csadqjoFkWGQTOedPoOunzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/middleware-host-header": "3.930.0",
+        "@aws-sdk/middleware-logger": "3.930.0",
+        "@aws-sdk/middleware-recursion-detection": "3.933.0",
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/region-config-resolver": "3.930.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@aws-sdk/util-user-agent-browser": "3.930.0",
+        "@aws-sdk/util-user-agent-node": "3.934.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.2",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/middleware-retry": "^4.4.9",
+        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.8",
+        "@smithy/util-defaults-mode-node": "^4.2.11",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.934.0.tgz",
+      "integrity": "sha512-b6k916ZxSrBwQPzeirncTIQXGnhps0HFOUakFt0ZEzjksePYUiEoU/SQ7VeY1j9JeAdJ24ejqddCiyLt99/3lg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/xml-builder": "3.930.0",
+        "@smithy/core": "^3.18.2",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.934.0.tgz",
+      "integrity": "sha512-Q6/FmXs2d9t6obcvvJtrUhKserODn8l9Lp9yRjL5+L2b8BdSxm94x0BN3dpLDqwz+XgTmMn8VaS+2rnaVc0wSA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.934.0.tgz",
+      "integrity": "sha512-bnpIGYm7Jy46dxZa1cxMQ1sF0n2iBIT+TpOPHK51sz1N2dYOicUVWUHMDgU2xIFOVcKaqV+GV4VyicMmvDBcBQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.934.0.tgz",
+      "integrity": "sha512-WJcfFik7MPIgjE8lmuDcCqddHKRMpifzoBzTZWqUJJWYXIy0rDfNzt6pn3/TMLwVgnCGjnXlw6dChTxLzO60RQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.934.0.tgz",
+      "integrity": "sha512-3vVKGe1F2S09G9kC0ZcpWh09opyrGOgQETllqWbuxlTVd7zBgrZWloItLIvneSDP+dWvdLFUbkD7WDWNCeGiig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/credential-provider-env": "3.934.0",
+        "@aws-sdk/credential-provider-http": "3.934.0",
+        "@aws-sdk/credential-provider-process": "3.934.0",
+        "@aws-sdk/credential-provider-sso": "3.934.0",
+        "@aws-sdk/credential-provider-web-identity": "3.934.0",
+        "@aws-sdk/nested-clients": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.934.0.tgz",
+      "integrity": "sha512-nguy36xi8nbH346dJjCmwWtOgfS4VfL7yHP+EEGmma+yg+J7mxgs8kA1NGQdJ8B46GdjlJPpI1P9pm7Pmz7nOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.934.0",
+        "@aws-sdk/credential-provider-http": "3.934.0",
+        "@aws-sdk/credential-provider-ini": "3.934.0",
+        "@aws-sdk/credential-provider-process": "3.934.0",
+        "@aws-sdk/credential-provider-sso": "3.934.0",
+        "@aws-sdk/credential-provider-web-identity": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.934.0.tgz",
+      "integrity": "sha512-PhvpAgoJ88IOuqlUws9nvHuPex2jK+WS+0s00BQcRTwqPP0jtLT7eql6UfCRduwv2sIy3m1wnWDUubvbpejp/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.934.0.tgz",
+      "integrity": "sha512-7wO86w95V9MZSYo2dunBKruKHdAUmgg9ccOSJSYGnPip1PPBK/rgSgQ8mDlYtFAW3/82bdeM/668QcgLT4+ofA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.934.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/token-providers": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.934.0.tgz",
+      "integrity": "sha512-hb+lvFxiAPcAvUorB0hrUd1kDjDRXhZgCi5426I8KUpGzZ+ALh8/ep0KXAiYe2yg9ZkyMUbMaMvYYhMFcbXRFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/nested-clients": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.934.0.tgz",
+      "integrity": "sha512-HWAy+bghnA4rCOJgW80BwZRUc231QZaXKkAhFF259lVjkzoCTWyvrFHL/dLaR0g6lq0Pu+ujMkn7FI7qrEm3eQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.934.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.934.0",
+        "@aws-sdk/credential-provider-env": "3.934.0",
+        "@aws-sdk/credential-provider-http": "3.934.0",
+        "@aws-sdk/credential-provider-ini": "3.934.0",
+        "@aws-sdk/credential-provider-node": "3.934.0",
+        "@aws-sdk/credential-provider-process": "3.934.0",
+        "@aws-sdk/credential-provider-sso": "3.934.0",
+        "@aws-sdk/credential-provider-web-identity": "3.934.0",
+        "@aws-sdk/nested-clients": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.2",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
+      "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
+      "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.933.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.933.0.tgz",
+      "integrity": "sha512-qgrMlkVKzTCAdNw2A05DC2sPBo0KRQ7wk+lbYSRJnWVzcrceJhnmhoZVV5PFv7JtchK7sHVcfm9lcpiyd+XaCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.930.0",
+        "@aws/lambda-invoke-store": "^0.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-ec2": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.930.0.tgz",
+      "integrity": "sha512-AJ9WiDBJLfByW5eMEStE2CsJM2e+KT8d7LaJ6JiRp0Lht5UU+Zj/Qd5dFGraNW449FVnWNk2OZF/vVYlqW2ShQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-format-url": "3.930.0",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.934.0.tgz",
+      "integrity": "sha512-68giGM2Zm9K6Qas14ws3Qo5wafpn0I8/L64fS9E6Rc6Tu0k+So73hupysw+9ZOzHwQS5FEBUqLOMtbUibAcjNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@smithy/core": "^3.18.2",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.934.0.tgz",
+      "integrity": "sha512-kRO61EMrDR4UuPlKAkziG6urcYXlhrFW/Ce5PjWFdjkm0ZOge75OFV1vhf/vE4Pmoop9jaAONX4E5BaIYrIQfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/middleware-host-header": "3.930.0",
+        "@aws-sdk/middleware-logger": "3.930.0",
+        "@aws-sdk/middleware-recursion-detection": "3.933.0",
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/region-config-resolver": "3.930.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@aws-sdk/util-user-agent-browser": "3.930.0",
+        "@aws-sdk/util-user-agent-node": "3.934.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.2",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/middleware-retry": "^4.4.9",
+        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.8",
+        "@smithy/util-defaults-mode-node": "^4.2.11",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
+      "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.934.0.tgz",
+      "integrity": "sha512-M0WEmgXDdUxapSfjplqJoVCBMcn0vQ5Jou0X/XiQwyVDbfvIyNSHUHyMXEIBAew9kVx9sfMMEYz3LXewvQxdCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/nested-clients": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+      "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
+      "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.930.0.tgz",
+      "integrity": "sha512-FW6Im17Zc7F5WT39XUgDOjtJO95Yu8rsmeRHf7z+Y3FamtTSzH4f713BD/qMyJBrZIlFACWlok/Uuvdl5/qtMg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.893.0.tgz",
+      "integrity": "sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
+      "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/types": "^4.9.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.934.0.tgz",
+      "integrity": "sha512-vPRR4PaqNmuOQJSzq4EAVwFHUaSpPtgDgCEc7AYbArIy+59fckb6JNddlrjx4w4iWbqO0d+7OC5PtRcIk0AcZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.0.tgz",
+      "integrity": "sha512-D1jAmAZQYMoPiacfgNf7AWhg3DFN3Wq/vQv3WINt9znwjzHp2x+WzdJFxxj7xZL7V1U79As6G8f7PorMYWBKsQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -706,20 +1558,19 @@
       }
     },
     "node_modules/@guardian/cdk": {
-      "version": "59.5.3",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-59.5.3.tgz",
-      "integrity": "sha512-p2AAGZeqm9rGj/2peFQM5HFH79S5h6xM4dDS0H2o4r7+U9SQRjT4E8B5o7iYvzU08kYtMYXALL+mn6+q0poREw==",
+      "version": "62.1.2",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-62.1.2.tgz",
+      "integrity": "sha512-JFd9w4luhbmzvlMjkJLdXYr12DSn0PUhTu3k2mgMyxZUQXAnkvcuz9rJr/rZm2I3f8opz2sZsIdFFFZkFeFTWA==",
       "dev": true,
       "dependencies": {
+        "@aws-sdk/client-ec2": "^3.908.0",
+        "@aws-sdk/client-ssm": "^3.925.0",
+        "@aws-sdk/credential-providers": "^3.925.0",
         "@oclif/core": "3.26.6",
-        "aws-sdk": "^2.1691.0",
         "chalk": "^4.1.2",
-        "codemaker": "^1.103.1",
-        "git-url-parse": "^15.0.0",
+        "codemaker": "^1.114.1",
+        "git-url-parse": "^16.0.1",
         "js-yaml": "^4.1.0",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.upperfirst": "^4.3.1",
         "read-pkg-up": "7.0.1",
         "yargs": "^17.7.2"
       },
@@ -727,9 +1578,9 @@
         "gu-cdk": "bin/gu-cdk"
       },
       "peerDependencies": {
-        "aws-cdk": "2.157.0",
-        "aws-cdk-lib": "2.157.0",
-        "constructs": "10.3.0"
+        "aws-cdk": "^2.1030.0",
+        "aws-cdk-lib": "^2.219.0",
+        "constructs": "^10.4.2"
       }
     },
     "node_modules/@guardian/eslint-config": {
@@ -1413,6 +2264,641 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
+      "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.3.tgz",
+      "integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.18.4",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.4.tgz",
+      "integrity": "sha512-o5tMqPZILBvvROfC8vC+dSVnWJl9a0u9ax1i1+Bq8515eYjUJqqk5XjjEsDLoeL5dSqGSh6WGdVx1eJ1E/Nwhw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
+      "integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
+      "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.5.tgz",
+      "integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.5.tgz",
+      "integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.5.tgz",
+      "integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.11.tgz",
+      "integrity": "sha512-eJXq9VJzEer1W7EQh3HY2PDJdEcEUnv6sKuNt4eVjyeNWcQFS4KmnY+CKkYOIR6tSqarn6bjjCqg1UB+8UJiPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.18.4",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.11.tgz",
+      "integrity": "sha512-EL5OQHvFOKneJVRgzRW4lU7yidSwp/vRJOe542bHgExN3KNThr1rlg0iE4k4SnA+ohC+qlUxoK+smKeAYPzfAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/service-error-classification": "^4.2.5",
+        "@smithy/smithy-client": "^4.9.7",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
+      "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
+      "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
+      "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
+      "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
+      "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
+      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
+      "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
+      "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.5.tgz",
+      "integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
+      "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
+      "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.7.tgz",
+      "integrity": "sha512-pskaE4kg0P9xNQWihfqlTMyxyFR3CH6Sr6keHYghgyqqDXzjl2QJg5lAzuVe/LzZiOzcbcVtxKYi1/fZPt/3DA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.18.4",
+        "@smithy/middleware-endpoint": "^4.3.11",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
+      "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
+      "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.10.tgz",
+      "integrity": "sha512-3iA3JVO1VLrP21FsZZpMCeF93aqP3uIOMvymAT3qHIJz2YlgDeRvNUspFwCNqd/j3qqILQJGtsVQnJZICh/9YA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/smithy-client": "^4.9.7",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.13.tgz",
+      "integrity": "sha512-PTc6IpnpSGASuzZAgyUtaVfOFpU0jBD2mcGwrgDuHf7PlFgt5TIPxCYBDbFQs06jxgeV3kd/d/sok1pzV0nJRg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/smithy-client": "^4.9.7",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.5.tgz",
+      "integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
+      "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.5.tgz",
+      "integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
+      "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.5.tgz",
+      "integrity": "sha512-Dbun99A3InifQdIrsXZ+QLcC0PGBPAdrl4cj1mTgJvyc9N2zf7QSxg8TBkzsCmGJdE3TLbO9ycwpY0EkWahQ/g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -1556,6 +3042,13 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "node_modules/@types/parse-path": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.0.3.tgz",
+      "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
@@ -2052,24 +3545,25 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.157.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.157.0.tgz",
-      "integrity": "sha512-x/6ZUm/JuQoSdbDUiNdPvKcwh5tsJl+Mk07RKJLSKagN179VJLQk5BzT4P+bFVMzAeYRMpURjPCOwjKbU1V7OQ==",
+      "version": "2.1031.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1031.1.tgz",
+      "integrity": "sha512-y/ovZDtOKvgJFtwE7NDFKRgJB3stgUUrAu6b31icuFO8+vnZ+4BIt0McQfbVR8ky5QOj2TW1G1sk55k8Yv+BnQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.0.0"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.157.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.157.0.tgz",
-      "integrity": "sha512-07uVY1MVool092wP+jb2XjPR9PFvF26VDDatY6BXR+AliW9sFZ4NKB7zzJrzZOyAbA3cTbedEca0EpRLZ7bjYw==",
+      "version": "2.222.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.222.0.tgz",
+      "integrity": "sha512-G+M6yUDc+GK3Ebb9ULLzjSkDwJ/AlL4Jbybq59tQQ0ZtcfXciPHVwutKuIgEWadJrRI5dPhCc+mGDYXTtKqirw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -2084,25 +3578,25 @@
         "mime-types"
       ],
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.202",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.3",
-        "@aws-cdk/cloud-assembly-schema": "^36.0.5",
+        "@aws-cdk/asset-awscli-v1": "2.2.242",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^48.6.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.2.0",
-        "ignore": "^5.3.1",
-        "jsonschema": "^1.4.1",
+        "fs-extra": "^11.3.1",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.6.2",
-        "table": "^6.8.2",
+        "semver": "^7.7.2",
+        "table": "^6.9.0",
         "yaml": "1.10.2"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 18.0.0"
       },
       "peerDependencies": {
         "constructs": "^10.0.0"
@@ -2115,15 +3609,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.16.0",
+      "version": "8.17.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -2170,7 +3664,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "1.1.11",
+      "version": "1.1.12",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2224,8 +3718,24 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.1.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.2.0",
+      "version": "11.3.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2245,7 +3755,7 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.3.1",
+      "version": "5.3.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2269,7 +3779,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.1.0",
+      "version": "6.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2281,7 +3791,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2347,7 +3857,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.6.2",
+      "version": "7.7.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2402,7 +3912,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.2",
+      "version": "6.9.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -2426,15 +3936,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/aws-cdk-lib/node_modules/uri-js": {
-      "version": "4.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
       "dev": true,
@@ -2442,28 +3943,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/aws-sdk": {
-      "version": "2.1691.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1691.0.tgz",
-      "integrity": "sha512-/F2YC+DlsY3UBM2Bdnh5RLHOPNibS/+IcjUuhP8XuctyrN+MlL+fWDAiela32LTDk7hMy4rx8MTgvbJ+0blO5g==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.16.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "util": "^0.12.4",
-        "uuid": "8.0.0",
-        "xml2js": "0.6.2"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/babel-jest": {
@@ -2563,25 +4042,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+    "node_modules/bowser": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.1.tgz",
+      "integrity": "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2657,17 +4123,6 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "dev": true,
-      "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
       }
     },
     "node_modules/buffer-from": {
@@ -2859,10 +4314,11 @@
       }
     },
     "node_modules/codemaker": {
-      "version": "1.104.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.104.0.tgz",
-      "integrity": "sha512-BC95gULaPN4MMeWxeLXHGatkac6LOArHMAkPkl3wQdcVa7MO4OzST6e8tY71iqA3KrgamfP0vQ34N9rDkfDyGg==",
+      "version": "1.119.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.119.0.tgz",
+      "integrity": "sha512-2l3t8Dc2y/jDVk0munVT3K5bPeanEpKsgCEwO0KsBY87MCxnTTzJCQxVyd7+AeVIy7LRMNkXfNAziVP53r6e9g==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "camelcase": "^6.3.0",
         "decamelize": "^5.0.1",
@@ -2926,13 +4382,11 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.3.0.tgz",
-      "integrity": "sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.2.tgz",
+      "integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==",
       "dev": true,
-      "engines": {
-        "node": ">= 16.14.0"
-      }
+      "license": "Apache-2.0"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -3054,6 +4508,7 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
       "integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3718,15 +5173,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3820,6 +5266,25 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -3944,6 +5409,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -4097,22 +5563,24 @@
       }
     },
     "node_modules/git-up": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/git-up/-/git-up-7.0.0.tgz",
-      "integrity": "sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-8.1.1.tgz",
+      "integrity": "sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-ssh": "^1.4.0",
-        "parse-url": "^8.1.0"
+        "parse-url": "^9.2.0"
       }
     },
     "node_modules/git-url-parse": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-15.0.0.tgz",
-      "integrity": "sha512-5reeBufLi+i4QD3ZFftcJs9jC26aULFLBU23FeKM/b1rI0K6ofIeAblmDVO7Ht22zTDE9+CkJ3ZVb0CgJmz3UQ==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-16.1.0.tgz",
+      "integrity": "sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "git-up": "^7.0.0"
+        "git-up": "^8.1.0"
       }
     },
     "node_modules/glob": {
@@ -4345,12 +5813,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4441,22 +5903,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4608,21 +6054,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dev": true,
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -4713,10 +6144,11 @@
       }
     },
     "node_modules/is-ssh": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz",
-      "integrity": "sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.1.tgz",
+      "integrity": "sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "protocols": "^2.0.1"
       }
@@ -4801,12 +6233,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -5458,15 +6884,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jmespath": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5534,10 +6951,11 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -5606,18 +7024,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true
-    },
-    "node_modules/lodash.kebabcase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
-      "dev": true
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5628,12 +7034,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
-    },
-    "node_modules/lodash.upperfirst": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
-      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true
     },
     "node_modules/lru-cache": {
@@ -6018,21 +7418,27 @@
       }
     },
     "node_modules/parse-path": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
-      "integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
+      "integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "protocols": "^2.0.0"
       }
     },
     "node_modules/parse-url": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-8.1.0.tgz",
-      "integrity": "sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-9.2.0.tgz",
+      "integrity": "sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "@types/parse-path": "^7.0.0",
         "parse-path": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.0"
       }
     },
     "node_modules/password-prompt": {
@@ -6252,10 +7658,11 @@
       }
     },
     "node_modules/protocols": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
-      "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
-      "dev": true
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
+      "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -6281,16 +7688,6 @@
           "url": "https://opencollective.com/fast-check"
         }
       ]
-    },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.x"
-      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -6610,12 +8007,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
-      "dev": true
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -6949,6 +8340,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -7198,8 +8602,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
       "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7346,6 +8749,7 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -7387,44 +8791,6 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
-    "node_modules/url/node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
-      "dev": true
-    },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -7579,28 +8945,6 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "dev": true,
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -7677,15 +9021,9 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.207",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.207.tgz",
-      "integrity": "sha512-5oRh5Ad7hGSqwM3+/X8MmIkUjBMGU9sd1g+pa3L0s8IL15OQcFW0ZT0gsUdEb/N/JV663jUUpSbtD7pLO65O4Q==",
-      "dev": true
-    },
-    "@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.3.tgz",
-      "integrity": "sha512-cDG1w3ieM6eOT9mTefRuTypk95+oyD7P5X/wRltwmYxU7nZc3+076YEVS6vrjDKr3ADYbfn0lDKpfB1FBtO9CQ==",
+      "version": "2.2.242",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.242.tgz",
+      "integrity": "sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==",
       "dev": true
     },
     "@aws-cdk/asset-node-proxy-agent-v6": {
@@ -7695,13 +9033,13 @@
       "dev": true
     },
     "@aws-cdk/cloud-assembly-schema": {
-      "version": "36.3.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-36.3.0.tgz",
-      "integrity": "sha512-mLSYgcMFTNCXrGAD7xob95p9s47/7WwEWUJiexxM46H2GxiijhlhLQJs31AS5uRRP6Cx1DLEu4qayKAUOOVGrw==",
+      "version": "48.19.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-48.19.0.tgz",
+      "integrity": "sha512-jefeDhIphmb/ahwqJ+kSbfUky3EPObDg34YIqmf6LfYMeI1/17I7eh5RopD7JfMyOizkE/H4K28sKGTSYrfiWg==",
       "dev": true,
       "requires": {
-        "jsonschema": "^1.4.1",
-        "semver": "^7.6.3"
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.2"
       },
       "dependencies": {
         "jsonschema": {
@@ -7710,11 +9048,714 @@
           "dev": true
         },
         "semver": {
-          "version": "7.6.3",
+          "version": "7.7.2",
           "bundled": true,
           "dev": true
         }
       }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/is-array-buffer": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+          "dev": true,
+          "requires": {
+            "@smithy/util-buffer-from": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "@smithy/is-array-buffer": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+          "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-buffer-from": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+          "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+          "dev": true,
+          "requires": {
+            "@smithy/is-array-buffer": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        },
+        "@smithy/util-utf8": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+          "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+          "dev": true,
+          "requires": {
+            "@smithy/util-buffer-from": "^2.2.0",
+            "tslib": "^2.6.2"
+          }
+        }
+      }
+    },
+    "@aws-sdk/client-cognito-identity": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.934.0.tgz",
+      "integrity": "sha512-kEuo8vPwZ4f1RmUlMs86yNkz35SAQlVtso+z6KBjJKGH+p6KkZ6dWvYno18fb0IdVbo4KGeCCXfnV5LoNLkLxQ==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/credential-provider-node": "3.934.0",
+        "@aws-sdk/middleware-host-header": "3.930.0",
+        "@aws-sdk/middleware-logger": "3.930.0",
+        "@aws-sdk/middleware-recursion-detection": "3.933.0",
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/region-config-resolver": "3.930.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@aws-sdk/util-user-agent-browser": "3.930.0",
+        "@aws-sdk/util-user-agent-node": "3.934.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.2",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/middleware-retry": "^4.4.9",
+        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.8",
+        "@smithy/util-defaults-mode-node": "^4.2.11",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/client-ec2": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.934.0.tgz",
+      "integrity": "sha512-VMTBq5zYkgDAz2a+EI0E/ALZgNamS3223jwFXksfHAujc91xhqzmiknl1Tpu60W2KgJGxRrX5f5mcSBZEHismw==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/credential-provider-node": "3.934.0",
+        "@aws-sdk/middleware-host-header": "3.930.0",
+        "@aws-sdk/middleware-logger": "3.930.0",
+        "@aws-sdk/middleware-recursion-detection": "3.933.0",
+        "@aws-sdk/middleware-sdk-ec2": "3.930.0",
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/region-config-resolver": "3.930.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@aws-sdk/util-user-agent-browser": "3.930.0",
+        "@aws-sdk/util-user-agent-node": "3.934.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.2",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/middleware-retry": "^4.4.9",
+        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.8",
+        "@smithy/util-defaults-mode-node": "^4.2.11",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/client-ssm": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ssm/-/client-ssm-3.934.0.tgz",
+      "integrity": "sha512-sZdZIvXTaaB7FqVUU7354xHhN3FFTm70b9IQ9rfWZvQ7kGdHRaCitRZR7f6NE51hhwdXWwwky3MsN6rEN8RJAA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/credential-provider-node": "3.934.0",
+        "@aws-sdk/middleware-host-header": "3.930.0",
+        "@aws-sdk/middleware-logger": "3.930.0",
+        "@aws-sdk/middleware-recursion-detection": "3.933.0",
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/region-config-resolver": "3.930.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@aws-sdk/util-user-agent-browser": "3.930.0",
+        "@aws-sdk/util-user-agent-node": "3.934.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.2",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/middleware-retry": "^4.4.9",
+        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.8",
+        "@smithy/util-defaults-mode-node": "^4.2.11",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.934.0.tgz",
+      "integrity": "sha512-gsgJevqhY0j3x014ejhXtHLCA6o83FYm3rJoZG7tqoy3DnWerLv/FHaAnHI/+Q+csadqjoFkWGQTOedPoOunzA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/middleware-host-header": "3.930.0",
+        "@aws-sdk/middleware-logger": "3.930.0",
+        "@aws-sdk/middleware-recursion-detection": "3.933.0",
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/region-config-resolver": "3.930.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@aws-sdk/util-user-agent-browser": "3.930.0",
+        "@aws-sdk/util-user-agent-node": "3.934.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.2",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/middleware-retry": "^4.4.9",
+        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.8",
+        "@smithy/util-defaults-mode-node": "^4.2.11",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/core": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.934.0.tgz",
+      "integrity": "sha512-b6k916ZxSrBwQPzeirncTIQXGnhps0HFOUakFt0ZEzjksePYUiEoU/SQ7VeY1j9JeAdJ24ejqddCiyLt99/3lg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/xml-builder": "3.930.0",
+        "@smithy/core": "^3.18.2",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.934.0.tgz",
+      "integrity": "sha512-Q6/FmXs2d9t6obcvvJtrUhKserODn8l9Lp9yRjL5+L2b8BdSxm94x0BN3dpLDqwz+XgTmMn8VaS+2rnaVc0wSA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.934.0.tgz",
+      "integrity": "sha512-bnpIGYm7Jy46dxZa1cxMQ1sF0n2iBIT+TpOPHK51sz1N2dYOicUVWUHMDgU2xIFOVcKaqV+GV4VyicMmvDBcBQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-http": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.934.0.tgz",
+      "integrity": "sha512-WJcfFik7MPIgjE8lmuDcCqddHKRMpifzoBzTZWqUJJWYXIy0rDfNzt6pn3/TMLwVgnCGjnXlw6dChTxLzO60RQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.934.0.tgz",
+      "integrity": "sha512-3vVKGe1F2S09G9kC0ZcpWh09opyrGOgQETllqWbuxlTVd7zBgrZWloItLIvneSDP+dWvdLFUbkD7WDWNCeGiig==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/credential-provider-env": "3.934.0",
+        "@aws-sdk/credential-provider-http": "3.934.0",
+        "@aws-sdk/credential-provider-process": "3.934.0",
+        "@aws-sdk/credential-provider-sso": "3.934.0",
+        "@aws-sdk/credential-provider-web-identity": "3.934.0",
+        "@aws-sdk/nested-clients": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.934.0.tgz",
+      "integrity": "sha512-nguy36xi8nbH346dJjCmwWtOgfS4VfL7yHP+EEGmma+yg+J7mxgs8kA1NGQdJ8B46GdjlJPpI1P9pm7Pmz7nOw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.934.0",
+        "@aws-sdk/credential-provider-http": "3.934.0",
+        "@aws-sdk/credential-provider-ini": "3.934.0",
+        "@aws-sdk/credential-provider-process": "3.934.0",
+        "@aws-sdk/credential-provider-sso": "3.934.0",
+        "@aws-sdk/credential-provider-web-identity": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.934.0.tgz",
+      "integrity": "sha512-PhvpAgoJ88IOuqlUws9nvHuPex2jK+WS+0s00BQcRTwqPP0jtLT7eql6UfCRduwv2sIy3m1wnWDUubvbpejp/Q==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.934.0.tgz",
+      "integrity": "sha512-7wO86w95V9MZSYo2dunBKruKHdAUmgg9ccOSJSYGnPip1PPBK/rgSgQ8mDlYtFAW3/82bdeM/668QcgLT4+ofA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/client-sso": "3.934.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/token-providers": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.934.0.tgz",
+      "integrity": "sha512-hb+lvFxiAPcAvUorB0hrUd1kDjDRXhZgCi5426I8KUpGzZ+ALh8/ep0KXAiYe2yg9ZkyMUbMaMvYYhMFcbXRFA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/nested-clients": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/credential-providers": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.934.0.tgz",
+      "integrity": "sha512-HWAy+bghnA4rCOJgW80BwZRUc231QZaXKkAhFF259lVjkzoCTWyvrFHL/dLaR0g6lq0Pu+ujMkn7FI7qrEm3eQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.934.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.934.0",
+        "@aws-sdk/credential-provider-env": "3.934.0",
+        "@aws-sdk/credential-provider-http": "3.934.0",
+        "@aws-sdk/credential-provider-ini": "3.934.0",
+        "@aws-sdk/credential-provider-node": "3.934.0",
+        "@aws-sdk/credential-provider-process": "3.934.0",
+        "@aws-sdk/credential-provider-sso": "3.934.0",
+        "@aws-sdk/credential-provider-web-identity": "3.934.0",
+        "@aws-sdk/nested-clients": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.2",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
+      "integrity": "sha512-x30jmm3TLu7b/b+67nMyoV0NlbnCVT5DI57yDrhXAPCtdgM1KtdLWt45UcHpKOm1JsaIkmYRh2WYu7Anx4MG0g==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
+      "integrity": "sha512-vh4JBWzMCBW8wREvAwoSqB2geKsZwSHTa0nSt0OMOLp2PdTYIZDi0ZiVMmpfnjcx9XbS6aSluLv9sKx4RrG46A==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.933.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.933.0.tgz",
+      "integrity": "sha512-qgrMlkVKzTCAdNw2A05DC2sPBo0KRQ7wk+lbYSRJnWVzcrceJhnmhoZVV5PFv7JtchK7sHVcfm9lcpiyd+XaCA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.930.0",
+        "@aws/lambda-invoke-store": "^0.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-ec2": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.930.0.tgz",
+      "integrity": "sha512-AJ9WiDBJLfByW5eMEStE2CsJM2e+KT8d7LaJ6JiRp0Lht5UU+Zj/Qd5dFGraNW449FVnWNk2OZF/vVYlqW2ShQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-format-url": "3.930.0",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.934.0.tgz",
+      "integrity": "sha512-68giGM2Zm9K6Qas14ws3Qo5wafpn0I8/L64fS9E6Rc6Tu0k+So73hupysw+9ZOzHwQS5FEBUqLOMtbUibAcjNA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@smithy/core": "^3.18.2",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/nested-clients": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.934.0.tgz",
+      "integrity": "sha512-kRO61EMrDR4UuPlKAkziG6urcYXlhrFW/Ce5PjWFdjkm0ZOge75OFV1vhf/vE4Pmoop9jaAONX4E5BaIYrIQfg==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/middleware-host-header": "3.930.0",
+        "@aws-sdk/middleware-logger": "3.930.0",
+        "@aws-sdk/middleware-recursion-detection": "3.933.0",
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/region-config-resolver": "3.930.0",
+        "@aws-sdk/types": "3.930.0",
+        "@aws-sdk/util-endpoints": "3.930.0",
+        "@aws-sdk/util-user-agent-browser": "3.930.0",
+        "@aws-sdk/util-user-agent-node": "3.934.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.2",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.9",
+        "@smithy/middleware-retry": "^4.4.9",
+        "@smithy/middleware-serde": "^4.2.5",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.8",
+        "@smithy/util-defaults-mode-node": "^4.2.11",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/region-config-resolver": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
+      "integrity": "sha512-KL2JZqH6aYeQssu1g1KuWsReupdfOoxD6f1as2VC+rdwYFUu4LfzMsFfXnBvvQWWqQ7rZHWOw1T+o5gJmg7Dzw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.934.0.tgz",
+      "integrity": "sha512-M0WEmgXDdUxapSfjplqJoVCBMcn0vQ5Jou0X/XiQwyVDbfvIyNSHUHyMXEIBAew9kVx9sfMMEYz3LXewvQxdCA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/core": "3.934.0",
+        "@aws-sdk/nested-clients": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
+      "integrity": "sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
+      "integrity": "sha512-M2oEKBzzNAYr136RRc6uqw3aWlwCxqTP1Lawps9E1d2abRPvl1p1ztQmmXp1Ak4rv8eByIZ+yQyKQ3zPdRG5dw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/util-format-url": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.930.0.tgz",
+      "integrity": "sha512-FW6Im17Zc7F5WT39XUgDOjtJO95Yu8rsmeRHf7z+Y3FamtTSzH4f713BD/qMyJBrZIlFACWlok/Uuvdl5/qtMg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.893.0.tgz",
+      "integrity": "sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
+      "integrity": "sha512-q6lCRm6UAe+e1LguM5E4EqM9brQlDem4XDcQ87NzEvlTW6GzmNCO0w1jS0XgCFXQHjDxjdlNFX+5sRbHijwklg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/types": "^4.9.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.934.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.934.0.tgz",
+      "integrity": "sha512-vPRR4PaqNmuOQJSzq4EAVwFHUaSpPtgDgCEc7AYbArIy+59fckb6JNddlrjx4w4iWbqO0d+7OC5PtRcIk0AcZA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/middleware-user-agent": "3.934.0",
+        "@aws-sdk/types": "3.930.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^4.9.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@aws/lambda-invoke-store": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.0.tgz",
+      "integrity": "sha512-D1jAmAZQYMoPiacfgNf7AWhg3DFN3Wq/vQv3WINt9znwjzHp2x+WzdJFxxj7xZL7V1U79As6G8f7PorMYWBKsQ==",
+      "dev": true
     },
     "@babel/code-frame": {
       "version": "7.25.7",
@@ -8178,20 +10219,19 @@
       "dev": true
     },
     "@guardian/cdk": {
-      "version": "59.5.3",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-59.5.3.tgz",
-      "integrity": "sha512-p2AAGZeqm9rGj/2peFQM5HFH79S5h6xM4dDS0H2o4r7+U9SQRjT4E8B5o7iYvzU08kYtMYXALL+mn6+q0poREw==",
+      "version": "62.1.2",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-62.1.2.tgz",
+      "integrity": "sha512-JFd9w4luhbmzvlMjkJLdXYr12DSn0PUhTu3k2mgMyxZUQXAnkvcuz9rJr/rZm2I3f8opz2sZsIdFFFZkFeFTWA==",
       "dev": true,
       "requires": {
+        "@aws-sdk/client-ec2": "^3.908.0",
+        "@aws-sdk/client-ssm": "^3.925.0",
+        "@aws-sdk/credential-providers": "^3.925.0",
         "@oclif/core": "3.26.6",
-        "aws-sdk": "^2.1691.0",
         "chalk": "^4.1.2",
-        "codemaker": "^1.103.1",
-        "git-url-parse": "^15.0.0",
+        "codemaker": "^1.114.1",
+        "git-url-parse": "^16.0.1",
         "js-yaml": "^4.1.0",
-        "lodash.camelcase": "^4.3.0",
-        "lodash.kebabcase": "^4.1.1",
-        "lodash.upperfirst": "^4.3.1",
         "read-pkg-up": "7.0.1",
         "yargs": "^17.7.2"
       }
@@ -8738,6 +10778,477 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "@smithy/abort-controller": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
+      "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/config-resolver": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.3.tgz",
+      "integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
+      "dev": true,
+      "requires": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/core": {
+      "version": "3.18.4",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.4.tgz",
+      "integrity": "sha512-o5tMqPZILBvvROfC8vC+dSVnWJl9a0u9ax1i1+Bq8515eYjUJqqk5XjjEsDLoeL5dSqGSh6WGdVx1eJ1E/Nwhw==",
+      "dev": true,
+      "requires": {
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/credential-provider-imds": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
+      "integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/fetch-http-handler": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
+      "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
+      "dev": true,
+      "requires": {
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/hash-node": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.5.tgz",
+      "integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/invalid-dependency": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.5.tgz",
+      "integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/is-array-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-content-length": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.5.tgz",
+      "integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
+      "dev": true,
+      "requires": {
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-endpoint": {
+      "version": "4.3.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.11.tgz",
+      "integrity": "sha512-eJXq9VJzEer1W7EQh3HY2PDJdEcEUnv6sKuNt4eVjyeNWcQFS4KmnY+CKkYOIR6tSqarn6bjjCqg1UB+8UJiPQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/core": "^3.18.4",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-retry": {
+      "version": "4.4.11",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.11.tgz",
+      "integrity": "sha512-EL5OQHvFOKneJVRgzRW4lU7yidSwp/vRJOe542bHgExN3KNThr1rlg0iE4k4SnA+ohC+qlUxoK+smKeAYPzfAQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/service-error-classification": "^4.2.5",
+        "@smithy/smithy-client": "^4.9.7",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-serde": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
+      "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/middleware-stack": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
+      "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/node-config-provider": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
+      "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
+      "dev": true,
+      "requires": {
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/node-http-handler": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
+      "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
+      "dev": true,
+      "requires": {
+        "@smithy/abort-controller": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/property-provider": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
+      "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/protocol-http": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
+      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/querystring-builder": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
+      "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/querystring-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
+      "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/service-error-classification": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.5.tgz",
+      "integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^4.9.0"
+      }
+    },
+    "@smithy/shared-ini-file-loader": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
+      "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/signature-v4": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
+      "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
+      "dev": true,
+      "requires": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/smithy-client": {
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.7.tgz",
+      "integrity": "sha512-pskaE4kg0P9xNQWihfqlTMyxyFR3CH6Sr6keHYghgyqqDXzjl2QJg5lAzuVe/LzZiOzcbcVtxKYi1/fZPt/3DA==",
+      "dev": true,
+      "requires": {
+        "@smithy/core": "^3.18.4",
+        "@smithy/middleware-endpoint": "^4.3.11",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/types": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
+      "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/url-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
+      "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/querystring-parser": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-base64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-body-length-browser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-body-length-node": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-buffer-from": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "dev": true,
+      "requires": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-config-provider": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-defaults-mode-browser": {
+      "version": "4.3.10",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.10.tgz",
+      "integrity": "sha512-3iA3JVO1VLrP21FsZZpMCeF93aqP3uIOMvymAT3qHIJz2YlgDeRvNUspFwCNqd/j3qqILQJGtsVQnJZICh/9YA==",
+      "dev": true,
+      "requires": {
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/smithy-client": "^4.9.7",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-defaults-mode-node": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.13.tgz",
+      "integrity": "sha512-PTc6IpnpSGASuzZAgyUtaVfOFpU0jBD2mcGwrgDuHf7PlFgt5TIPxCYBDbFQs06jxgeV3kd/d/sok1pzV0nJRg==",
+      "dev": true,
+      "requires": {
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/smithy-client": "^4.9.7",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-endpoints": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.5.tgz",
+      "integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
+      "dev": true,
+      "requires": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-hex-encoding": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-middleware": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
+      "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
+      "dev": true,
+      "requires": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-retry": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.5.tgz",
+      "integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
+      "dev": true,
+      "requires": {
+        "@smithy/service-error-classification": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-stream": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
+      "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
+      "dev": true,
+      "requires": {
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-uri-escape": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-utf8": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "dev": true,
+      "requires": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/util-waiter": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.5.tgz",
+      "integrity": "sha512-Dbun99A3InifQdIrsXZ+QLcC0PGBPAdrl4cj1mTgJvyc9N2zf7QSxg8TBkzsCmGJdE3TLbO9ycwpY0EkWahQ/g==",
+      "dev": true,
+      "requires": {
+        "@smithy/abort-controller": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@smithy/uuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.6.2"
+      }
+    },
     "@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -8880,6 +11391,12 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "@types/parse-path": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse-path/-/parse-path-7.0.3.tgz",
+      "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
       "dev": true
     },
     "@types/semver": {
@@ -9207,34 +11724,33 @@
       }
     },
     "aws-cdk": {
-      "version": "2.157.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.157.0.tgz",
-      "integrity": "sha512-x/6ZUm/JuQoSdbDUiNdPvKcwh5tsJl+Mk07RKJLSKagN179VJLQk5BzT4P+bFVMzAeYRMpURjPCOwjKbU1V7OQ==",
+      "version": "2.1031.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1031.1.tgz",
+      "integrity": "sha512-y/ovZDtOKvgJFtwE7NDFKRgJB3stgUUrAu6b31icuFO8+vnZ+4BIt0McQfbVR8ky5QOj2TW1G1sk55k8Yv+BnQ==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"
       }
     },
     "aws-cdk-lib": {
-      "version": "2.157.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.157.0.tgz",
-      "integrity": "sha512-07uVY1MVool092wP+jb2XjPR9PFvF26VDDatY6BXR+AliW9sFZ4NKB7zzJrzZOyAbA3cTbedEca0EpRLZ7bjYw==",
+      "version": "2.222.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.222.0.tgz",
+      "integrity": "sha512-G+M6yUDc+GK3Ebb9ULLzjSkDwJ/AlL4Jbybq59tQQ0ZtcfXciPHVwutKuIgEWadJrRI5dPhCc+mGDYXTtKqirw==",
       "dev": true,
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.202",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.3",
-        "@aws-cdk/cloud-assembly-schema": "^36.0.5",
+        "@aws-cdk/asset-awscli-v1": "2.2.242",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^48.6.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.2.0",
-        "ignore": "^5.3.1",
-        "jsonschema": "^1.4.1",
+        "fs-extra": "^11.3.1",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.6.2",
-        "table": "^6.8.2",
+        "semver": "^7.7.2",
+        "table": "^6.9.0",
         "yaml": "1.10.2"
       },
       "dependencies": {
@@ -9244,14 +11760,14 @@
           "dev": true
         },
         "ajv": {
-          "version": "8.16.0",
+          "version": "8.17.1",
           "bundled": true,
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
             "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.4.1"
+            "require-from-string": "^2.0.2"
           }
         },
         "ansi-regex": {
@@ -9278,7 +11794,7 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "1.1.11",
+          "version": "1.1.12",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -9319,8 +11835,13 @@
           "bundled": true,
           "dev": true
         },
+        "fast-uri": {
+          "version": "3.1.0",
+          "bundled": true,
+          "dev": true
+        },
         "fs-extra": {
-          "version": "11.2.0",
+          "version": "11.3.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -9335,7 +11856,7 @@
           "dev": true
         },
         "ignore": {
-          "version": "5.3.1",
+          "version": "5.3.2",
           "bundled": true,
           "dev": true
         },
@@ -9350,7 +11871,7 @@
           "dev": true
         },
         "jsonfile": {
-          "version": "6.1.0",
+          "version": "6.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -9359,7 +11880,7 @@
           }
         },
         "jsonschema": {
-          "version": "1.4.1",
+          "version": "1.5.0",
           "bundled": true,
           "dev": true
         },
@@ -9400,7 +11921,7 @@
           "dev": true
         },
         "semver": {
-          "version": "7.6.2",
+          "version": "7.7.2",
           "bundled": true,
           "dev": true
         },
@@ -9433,7 +11954,7 @@
           }
         },
         "table": {
-          "version": "6.8.2",
+          "version": "6.9.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -9449,37 +11970,11 @@
           "bundled": true,
           "dev": true
         },
-        "uri-js": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "punycode": "^2.1.0"
-          }
-        },
         "yaml": {
           "version": "1.10.2",
           "bundled": true,
           "dev": true
         }
-      }
-    },
-    "aws-sdk": {
-      "version": "2.1691.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1691.0.tgz",
-      "integrity": "sha512-/F2YC+DlsY3UBM2Bdnh5RLHOPNibS/+IcjUuhP8XuctyrN+MlL+fWDAiela32LTDk7hMy4rx8MTgvbJ+0blO5g==",
-      "dev": true,
-      "requires": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.16.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "util": "^0.12.4",
-        "uuid": "8.0.0",
-        "xml2js": "0.6.2"
       }
     },
     "babel-jest": {
@@ -9558,10 +12053,10 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+    "bowser": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.1.tgz",
+      "integrity": "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==",
       "dev": true
     },
     "brace-expansion": {
@@ -9611,17 +12106,6 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "dev": true,
-      "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
       }
     },
     "buffer-from": {
@@ -9746,9 +12230,9 @@
       "dev": true
     },
     "codemaker": {
-      "version": "1.104.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.104.0.tgz",
-      "integrity": "sha512-BC95gULaPN4MMeWxeLXHGatkac6LOArHMAkPkl3wQdcVa7MO4OzST6e8tY71iqA3KrgamfP0vQ34N9rDkfDyGg==",
+      "version": "1.119.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.119.0.tgz",
+      "integrity": "sha512-2l3t8Dc2y/jDVk0munVT3K5bPeanEpKsgCEwO0KsBY87MCxnTTzJCQxVyd7+AeVIy7LRMNkXfNAziVP53r6e9g==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",
@@ -9804,9 +12288,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.3.0.tgz",
-      "integrity": "sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.2.tgz",
+      "integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==",
       "dev": true
     },
     "convert-source-map": {
@@ -10381,12 +12865,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
-      "dev": true
-    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -10464,6 +12942,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "dev": true,
+      "requires": {
+        "strnum": "^2.1.0"
+      }
     },
     "fastq": {
       "version": "1.17.1",
@@ -10672,22 +13159,22 @@
       }
     },
     "git-up": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/git-up/-/git-up-7.0.0.tgz",
-      "integrity": "sha512-ONdIrbBCFusq1Oy0sC71F5azx8bVkvtZtMJAsv+a6lz5YAmbNnLD6HAB4gptHZVLPR8S2/kVN6Gab7lryq5+lQ==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-8.1.1.tgz",
+      "integrity": "sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g==",
       "dev": true,
       "requires": {
         "is-ssh": "^1.4.0",
-        "parse-url": "^8.1.0"
+        "parse-url": "^9.2.0"
       }
     },
     "git-url-parse": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-15.0.0.tgz",
-      "integrity": "sha512-5reeBufLi+i4QD3ZFftcJs9jC26aULFLBU23FeKM/b1rI0K6ofIeAblmDVO7Ht22zTDE9+CkJ3ZVb0CgJmz3UQ==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-16.1.0.tgz",
+      "integrity": "sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw==",
       "dev": true,
       "requires": {
-        "git-up": "^7.0.0"
+        "git-up": "^8.1.0"
       }
     },
     "glob": {
@@ -10850,12 +13337,6 @@
       "integrity": "sha512-Ty8UblRWFEcfSuIaajM34LdPXIhbs1ajEX/BBPv24J+enSVaEVY63xQ6lTO9VRYS5LAoghIG0IDJ+p+IPzKUQQ==",
       "dev": true
     },
-    "ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
-    },
     "ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -10919,16 +13400,6 @@
         "es-errors": "^1.3.0",
         "hasown": "^2.0.0",
         "side-channel": "^1.0.4"
-      }
-    },
-    "is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
       }
     },
     "is-array-buffer": {
@@ -11023,15 +13494,6 @@
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
     },
-    "is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -11088,9 +13550,9 @@
       }
     },
     "is-ssh": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.0.tgz",
-      "integrity": "sha512-x7+VxdxOdlV3CYpjvRLBv5Lo9OJerlYanjwFrPR9fuGPjCiNiCzFgAWpiLAohSbsnH4ZAys3SBh+hq5rJosxUQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.1.tgz",
+      "integrity": "sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==",
       "dev": true,
       "requires": {
         "protocols": "^2.0.1"
@@ -11146,12 +13608,6 @@
       "requires": {
         "is-docker": "^2.0.0"
       }
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -11660,12 +14116,6 @@
         "supports-color": "^8.0.0"
       }
     },
-    "jmespath": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11718,9 +14168,9 @@
       "dev": true
     },
     "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6",
@@ -11773,18 +14223,6 @@
         "p-locate": "^5.0.0"
       }
     },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true
-    },
-    "lodash.kebabcase": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
-      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
-      "dev": true
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -11795,12 +14233,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
-    },
-    "lodash.upperfirst": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
-      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
       "dev": true
     },
     "lru-cache": {
@@ -12086,20 +14518,21 @@
       }
     },
     "parse-path": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.0.0.tgz",
-      "integrity": "sha512-Euf9GG8WT9CdqwuWJGdf3RkUcTBArppHABkO7Lm8IzRQp0e2r/kkFnmhu4TSK30Wcu5rVAZLmfPKSBBi9tWFog==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
+      "integrity": "sha512-EuCycjZtfPcjWk7KTksnJ5xPMvWGA/6i4zrLYhRG0hGvC3GPU/jGUj3Cy+ZR0v30duV3e23R95T1lE2+lsndSw==",
       "dev": true,
       "requires": {
         "protocols": "^2.0.0"
       }
     },
     "parse-url": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-8.1.0.tgz",
-      "integrity": "sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-9.2.0.tgz",
+      "integrity": "sha512-bCgsFI+GeGWPAvAiUv63ZorMeif3/U0zaXABGJbOWt5OH2KCaPHF6S+0ok4aqM9RuIPGyZdx9tR9l13PsW4AYQ==",
       "dev": true,
       "requires": {
+        "@types/parse-path": "^7.0.0",
         "parse-path": "^7.0.0"
       }
     },
@@ -12257,9 +14690,9 @@
       }
     },
     "protocols": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
-      "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
+      "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
       "dev": true
     },
     "punycode": {
@@ -12272,12 +14705,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "dev": true
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
       "dev": true
     },
     "queue-microtask": {
@@ -12495,12 +14922,6 @@
         "es-errors": "^1.3.0",
         "is-regex": "^1.1.4"
       }
-    },
-    "sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
-      "dev": true
     },
     "semver": {
       "version": "7.6.3",
@@ -12760,6 +15181,12 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "dev": true
+    },
     "supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -12918,8 +15345,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
       "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "type-check": {
       "version": "0.4.0",
@@ -13043,43 +15469,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
-      "dev": true,
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
-          "dev": true
-        }
-      }
-    },
-    "util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
-    "uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-      "dev": true
-    },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -13198,22 +15587,6 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       }
-    },
-    "xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "dev": true,
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "dev": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -15,14 +15,14 @@
     "diff": "cdk diff --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "59.5.3",
+    "@guardian/cdk": "62.1.2",
     "@guardian/eslint-config-typescript": "8.0.0",
     "@guardian/prettier": "3.0.0",
     "@types/jest": "^29.5.13",
     "@types/node": "22.7.5",
-    "aws-cdk": "2.157.0",
-    "aws-cdk-lib": "2.157.0",
-    "constructs": "10.3.0",
+    "aws-cdk": "2.1031.1",
+    "aws-cdk-lib": "2.222.0",
+    "constructs": "10.4.2",
     "eslint": "^8.57.1",
     "jest": "^29.7.0",
     "prettier": "^2.4.0",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As part of the AWS JavaScript SDK upgrade work, this pull request bumps the GuCDK to a newer version 62.1.2 that depends on AWS SDK v3 instead of v2.

## How to test

The CDK is more a build tool for generating the cloudformation JSON file.  So we can compare the snapshot files generated from our test (before and after the change) and check for any changes to the resources defined by us (some resources are defined by CDK for some of their features).

We can also do a smoke test on CODE:

1. Open a Composer on CODE and check if it gets 200 response from telemetry service.
<img width="685" alt="Screenshot 2025-11-20 at 10 08 52" src="https://github.com/user-attachments/assets/b278fee2-587b-417d-8cfc-b8ab8be15f7a" />

2. Check logs if the event can be found.
<img width="700" alt="Screenshot 2025-11-20 at 10 08 33" src="https://github.com/user-attachments/assets/b2117fab-d167-4363-b068-21d64b63df19" />

3. Check logs for any error logs.