### PR TITLE
Update actions-riff-raff to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
 
       - uses: guardian/actions-riff-raff@v4
         with:
-          role-arn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           projectName: Editorial Tools::Telemetry Service event lambda
           buildNumberOffset: 187


### PR DESCRIPTION
## What does this change?

This PR updates [actions-riff-raff](https://github.com/guardian/actions-riff-raff/) to v4 to get the new features. (I love the deployment comment!)

## How to test

Does actions-riff-raff run on this PR and leave a comment with a deploy link that works?