### PR TITLE
Adds TEST stage to determineStageFromHostname function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Start LocalStack
         run: |
           pip install localstack awscli-local[ver1] # install LocalStack cli and awslocal
-          docker pull localstack/localstack         # Make sure to pull the latest version of the image
+          docker pull localstack/localstack:4.14.0   # Make sure to pull the latest version of the image
           localstack start -d                       # Start LocalStack in the background
 
           echo "Waiting for LocalStack startup..."  # Wait 30 seconds for the LocalStack container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,12 @@ jobs:
 
       - name: Start LocalStack
         run: |
-          pip install localstack awscli-local[ver1] # install LocalStack cli and awslocal
-          docker pull localstack/localstack:4.14.0   # Make sure to pull the latest version of the image
-          localstack start -d                       # Start LocalStack in the background
+          pip install localstack==4.14.0 awscli-local[ver1]  # install LocalStack cli 4.14.0 and awslocal
+          docker pull localstack/localstack:4.14.0           # Make sure to pull version 4.14.0 of the image
+          localstack start -d -s localstack:4.14.0           # Start LocalStack in the background
 
-          echo "Waiting for LocalStack startup..."  # Wait 30 seconds for the LocalStack container
-          localstack wait -t 30                     # to become ready before timing out 
+          echo "Waiting for LocalStack startup..."   # Wait 30 seconds for the LocalStack container
+          localstack wait -t 30                      # to become ready before timing out 
           echo "Startup complete"
 
       - name: Create LocalStack resources

--- a/projects/event-lambdas/src/lib/__tests__/utils.spec.ts
+++ b/projects/event-lambdas/src/lib/__tests__/utils.spec.ts
@@ -38,7 +38,7 @@ describe("utils", () => {
       expect(determineStageFromHostname("user-telemetry.code.dev-gutools.co.uk")).toBe("CODE");
     });
 
-    it("returns CODE for .code.dev-gutools.co.uk domains", () => {
+    it("returns TEST for .test.dev-gutools.co.uk domains", () => {
       expect(determineStageFromHostname("workflow.test.dev-gutools.co.uk")).toBe("TEST");
       expect(determineStageFromHostname("grid.test.dev-gutools.co.uk")).toBe("TEST");
       expect(determineStageFromHostname("user-telemetry.test.dev-gutools.co.uk")).toBe("TEST");

--- a/projects/event-lambdas/src/lib/__tests__/utils.spec.ts
+++ b/projects/event-lambdas/src/lib/__tests__/utils.spec.ts
@@ -38,6 +38,12 @@ describe("utils", () => {
       expect(determineStageFromHostname("user-telemetry.code.dev-gutools.co.uk")).toBe("CODE");
     });
 
+    it("returns CODE for .code.dev-gutools.co.uk domains", () => {
+      expect(determineStageFromHostname("workflow.test.dev-gutools.co.uk")).toBe("TEST");
+      expect(determineStageFromHostname("grid.test.dev-gutools.co.uk")).toBe("TEST");
+      expect(determineStageFromHostname("user-telemetry.test.dev-gutools.co.uk")).toBe("TEST");
+    });
+
     it("returns LOCAL for .local.dev-gutools.co.uk domains", () => {
       expect(determineStageFromHostname("workflow.local.dev-gutools.co.uk")).toBe("LOCAL");
       expect(determineStageFromHostname("composer.local.dev-gutools.co.uk")).toBe("LOCAL");

--- a/projects/event-lambdas/src/lib/util.ts
+++ b/projects/event-lambdas/src/lib/util.ts
@@ -25,7 +25,7 @@ export const determineStageFromHostname = (hostname: string): string | undefined
     return undefined;
   }
   
-  const stageMatch = /^.*\.(?<environment>local|code)\.dev-gutools\.co\.uk$|^.*\.gutools\.co\.uk$/.exec(hostname);
+  const stageMatch = /^.*\.(?<environment>local|code|test)\.dev-gutools\.co\.uk$|^.*\.gutools\.co\.uk$/.exec(hostname);
   if (stageMatch) {
     return (stageMatch.groups?.environment || "PROD").toUpperCase();
   }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
Adds TEST as recognised stage to to the `determineStageFromHostname` in order to support the Grid's TEST domain.

## How has this change been tested?

<!-- For example, have you deployed your branch to `CODE` and tested certain functionality or is unit testing sufficent for this change? If you'd like help testing your changes as part of the PR review process then mention that explicitly here. -->
Unit tests added! 

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->
The Grid test can successfully submit messages without the stage attribute present. 
